### PR TITLE
Implement JSON Patch for multiples devices

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -35,6 +35,7 @@
     <flapdoodle.version>2.2.0</flapdoodle.version>
     <guava.version>28.0-jre</guava.version>
     <caffeine.version>2.8.0</caffeine.version>
+    <glassfish.version>1.1.4</glassfish.version>
     <hamcrest-core.version>2.2</hamcrest-core.version>
     <infinispan.version>10.1.8.Final</infinispan.version>
     <infinispan.image.name>jboss/infinispan-server:9.4.11.Final</infinispan.image.name>
@@ -106,6 +107,11 @@
         <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client</artifactId>
         <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.json</artifactId>
+        <version>${glassfish.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/RegistryManagementConstants.java
@@ -58,7 +58,7 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      */
     public static final String TENANT_HTTP_ENDPOINT = "tenants";
 
-    // FIELD DEFINTIONS
+    // FIELD DEFINITIONS
 
     // DEVICES
 
@@ -82,6 +82,11 @@ public final class RegistryManagementConstants extends RequestResponseApiConstan
      * The name of the field that contains the names of the gateway groups that the (gateway) device is a member of.
      */
     public static final String FIELD_MEMBER_OF = "memberOf";
+
+    /**
+     * The name of the field that contains patch data for a PATCH request.
+     */
+    public static final String FIELD_PATCH_DATA = "patch";
 
     // CREDENTIALS
 

--- a/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/AbstractHttpEndpoint.java
@@ -112,7 +112,8 @@ public abstract class AbstractHttpEndpoint<T extends ServiceConfigProperties> ex
         final MIMEHeader contentType = ctx.parsedHeaders().contentType();
         if (contentType == null) {
             ctx.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "Missing Content-Type header"));
-        } else if (!HttpUtils.CONTENT_TYPE_JSON.equalsIgnoreCase(contentType.value())) {
+        } else if ( !(HttpUtils.CONTENT_TYPE_JSON.equalsIgnoreCase(contentType.value()) ||
+                    HttpUtils.CONTENT_TYPE_JSON_PATCH.equalsIgnoreCase(contentType.value()))) {
             ctx.fail(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST, "Unsupported Content-Type"));
         } else {
             try {

--- a/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/http/HttpUtils.java
@@ -45,6 +45,10 @@ public final class HttpUtils {
      */
     public static final String CONTENT_TYPE_JSON = "application/json";
     /**
+     * The <em>application/json-patch</em> content type.
+     */
+    public static final String CONTENT_TYPE_JSON_PATCH = "application/json-patch";
+    /**
      * The <em>application/json; charset=utf-8</em> content type.
      */
     public static final String CONTENT_TYPE_JSON_UTF8 = "application/json; charset=utf-8";

--- a/services/device-registry-base/pom.xml
+++ b/services/device-registry-base/pom.xml
@@ -31,6 +31,10 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
     </dependency>
+      <dependency>
+          <groupId>org.glassfish</groupId>
+          <artifactId>javax.json</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DeviceManagementService.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.service.management.device;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.eclipse.hono.service.management.Id;
@@ -21,6 +22,7 @@ import org.eclipse.hono.service.management.Result;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 
 /**
  * A service for managing device registration information.
@@ -106,4 +108,24 @@ public interface DeviceManagementService {
      *      Device Registry Management API - Delete Device Registration</a>
      */
     Future<Result<Void>> deleteDevice(String tenantId, String deviceId, Optional<String> resourceVersion, Span span);
+
+    /**
+     * Apply a patch to a list of devices.
+     *
+     * @param tenantId The tenant the device belongs to.
+     * @param deviceIds A list of devices ID to apply the patch to.
+     * @param patch The Json patch, following RFC 6902.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *          An implementation should log (error) events on this span and it may set tags and use this span as the
+     *          parent for any spans created in this method.
+     * @return  A future indicating the outcome of the operation.
+     *         The <em>status code</em> is set as specified in the
+     *         <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/patchRegistration">
+     *         Device Registry Management API - Patch Device Registration </a>
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     * @see <a href="https://www.eclipse.org/hono/docs/api/management/#/devices/patchRegistration">
+     *      Device Registry Management API - Patch Device Registration</a>
+     */
+    Future<Result<Void>> patchDevice(String tenantId, List deviceIds, JsonArray patch, Span span);
+
 }

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedDeviceBackend.java
@@ -47,6 +47,7 @@ import io.opentracing.noop.NoopSpan;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -169,6 +170,12 @@ public class FileBasedDeviceBackend implements AutoProvisioningEnabledDeviceBack
     public Future<OperationResult<Id>> updateDevice(final String tenantId, final String deviceId, final Device device,
             final Optional<String> resourceVersion, final Span span) {
         return registrationService.updateDevice(tenantId, deviceId, device, resourceVersion, span);
+    }
+
+    @Override
+    public Future<Result<Void>> patchDevice(final String tenantId, final List deviceIds,
+                                            final JsonArray patch, final Span span) {
+        return registrationService.patchDevice(tenantId, deviceIds, patch, span);
     }
 
     // CREDENTIALS

--- a/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
+++ b/services/device-registry-file/src/main/java/org/eclipse/hono/deviceregistry/file/FileBasedRegistrationService.java
@@ -430,6 +430,11 @@ public class FileBasedRegistrationService extends AbstractRegistrationService
         return Future.succeededFuture(processCreateDevice(tenantId, deviceId, device, span));
     }
 
+    @Override
+    public Future<Result<Void>> patchDevice(final String tenantId, final List deviceIds, final JsonArray patch, final Span span) {
+        return Future.succeededFuture(OperationResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
+    }
+
     /**
      * Adds a device to this registry.
      *

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceBackend.java
@@ -35,6 +35,7 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -94,6 +95,12 @@ public class MongoDbBasedDeviceBackend implements AutoProvisioningEnabledDeviceB
                             span)
                             .map(result);
                 });
+    }
+
+    @Override
+    public Future<Result<Void>> patchDevice(final String tenantId, final List deviceIds,
+                                            final JsonArray patch, final Span span) {
+        return registrationService.patchDevice(tenantId, deviceIds, patch, span);
     }
 
     @Override

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationService.java
@@ -177,6 +177,11 @@ public final class MongoDbBasedRegistrationService extends AbstractRegistrationS
                 .recover(error -> Future.succeededFuture(MongoDbDeviceRegistryUtils.mapErrorToResult(error, span)));
     }
 
+    @Override
+    public Future<Result<Void>> patchDevice(final String tenantId, final List deviceIds, final JsonArray patch, final Span span) {
+       return Future.succeededFuture(OperationResult.from(HttpURLConnection.HTTP_NOT_IMPLEMENTED));
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
allows to update parts of multiples devices registration data, using the json patch format. 

It allows the device registry implementation to override it, as some more features might be needed (such as transaction operations on database, atomic changes etc...).

I had to add a dependency on eclipse Glassfish, as Vert.x does not support Json Patch.

Here is how it works, assuming devices 4711 exist (but not 4713) : 
```
 curl --insecure -X PATCH -i -H 'Content-Type: application/json-patch' http://localhost:28080/v1/devices/DEFAULT_TENANT -d '{             
    "id" : ["4711", "4713"],
    "patch": [
    {
        "op": "add",
        "path": "/enabled",
        "value": true
    },
    {
        "op": "add",
        "path": "/ext",
        "value": {
            "key": "value"
        }
    }
]
}'
```
And the result would be : 
```
HTTP/1.1 201 Created
content-type: application/json; charset=utf-8
content-length: 234

{"4711":{"status":204,"resource-version":"1d8fe6ab-311e-4f9d-95b3-832bc90e35fa"},"4713":{"status":404,"error-message":"device '4713' cannot be retrieved"}}              
```

This is a draft as I still need to update the doc and add some unit tests. 

Some resources : 
http://jsonpatch.com/
https://json-patch-builder-online.github.io/

Signed-off-by: Jean-Baptiste Trystram <jbtrystram@redhat.com>