### PR TITLE
Add ApplicationClient addOnClientReadyHandler()

### DIFF
--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClient.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/KafkaApplicationClient.java
@@ -17,7 +17,6 @@ import org.eclipse.hono.application.client.ApplicationClient;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageConsumer;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
@@ -58,12 +57,4 @@ public interface KafkaApplicationClient extends ApplicationClient<KafkaMessageCo
             String tenantId,
             Handler<DownstreamMessage<KafkaMessageContext>> messageHandler,
             Handler<Throwable> closeHandler);
-
-    /**
-     * Adds a handler to be invoked with a succeeded future once this client is ready to be used.
-     * This may be when the {@link #start()} result future is completed or some time afterwards.
-     *
-     * @param handler The handler to invoke. The handler will never be invoked with a failed future.
-     */
-    void addOnClientReadyHandler(Handler<AsyncResult<Void>> handler);
 }

--- a/clients/application/src/main/java/org/eclipse/hono/application/client/ApplicationClient.java
+++ b/clients/application/src/main/java/org/eclipse/hono/application/client/ApplicationClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,6 +13,7 @@
 
 package org.eclipse.hono.application.client;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
@@ -110,4 +111,12 @@ public interface ApplicationClient<T extends MessageContext> extends CommandSend
             String replyId,
             Handler<DownstreamMessage<T>> messageHandler,
             Handler<Throwable> closeHandler);
+
+    /**
+     * Adds a handler to be invoked with a succeeded future once this client is ready to be used.
+     * This may be when the {@link #start()} result future is completed or some time afterwards.
+     *
+     * @param handler The handler to invoke. The handler will never be invoked with a failed future.
+     */
+    void addOnClientReadyHandler(Handler<AsyncResult<Void>> handler);
 }

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -129,7 +129,7 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
     public Future<Void> stop() {
         stopped = true;
         Optional.ofNullable(lastKnownGatewaysUpdateTimerId).ifPresent(tid -> connection.getVertx().cancelTimer(tid));
-        return super.stop();
+        return disconnectOnStop();
     }
 
     @Override

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedInternalCommandConsumer.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedInternalCommandConsumer.java
@@ -76,7 +76,7 @@ public class ProtonBasedInternalCommandConsumer extends AbstractServiceClient im
 
     @Override
     public Future<Void> start() {
-        return super.start()
+        return connectOnStart()
                 .onComplete(v -> {
                     connection.addReconnectListener(c -> recreateConsumer());
                     // trigger creation of adapter specific consumer link (with retry if failed)

--- a/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationReceiver.java
+++ b/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationReceiver.java
@@ -74,7 +74,7 @@ public class ProtonBasedNotificationReceiver extends AbstractServiceClient imple
         if (!startCalled.compareAndSet(false, true)) {
             return Future.succeededFuture();
         }
-        return super.start()
+        return connectOnStart()
                 .onComplete(v -> {
                     if (addresses.isEmpty()) {
                         log.warn("no notification consumers registered - nothing to do");
@@ -93,7 +93,7 @@ public class ProtonBasedNotificationReceiver extends AbstractServiceClient imple
         }
         addresses.clear();
         handlerPerType.clear();
-        return super.stop();
+        return disconnectOnStop();
     }
 
     @Override

--- a/core/src/main/java/org/eclipse/hono/util/Lifecycle.java
+++ b/core/src/main/java/org/eclipse/hono/util/Lifecycle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -24,7 +24,7 @@ public interface Lifecycle {
     /**
      * Starts this component.
      * <p>
-     * This method should be used to allocate any required resources.
+     * Implementing classes should use this method to allocate any required resources.
      * However, no long running tasks should be executed.
      *
      * @return A future indicating the outcome of the startup process.
@@ -34,7 +34,7 @@ public interface Lifecycle {
     /**
      * Stops this component.
      * <p>
-     * This method should be used to release any allocated resources.
+     * Implementing classes should use this method to release any allocated resources.
      * However, no long running tasks should be executed.
      *
      * @return A future indicating the outcome of the shut down process.

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedCommandConsumerFactoryImpl.java
@@ -110,7 +110,7 @@ public class ProtonBasedCommandConsumerFactoryImpl extends AbstractServiceClient
     @Override
     public Future<Void> start() {
         registerCloseConsumerLinkHandler();
-        return CompositeFuture.all(super.start(), mappingAndDelegatingCommandHandler.start())
+        return CompositeFuture.all(connectOnStart(), mappingAndDelegatingCommandHandler.start())
                 .map((Void) null)
                 .onSuccess(v -> {
                     connection.addReconnectListener(c -> recreateConsumers());
@@ -121,7 +121,7 @@ public class ProtonBasedCommandConsumerFactoryImpl extends AbstractServiceClient
 
     @Override
     public Future<Void> stop() {
-        return CompositeFuture.join(super.stop(), mappingAndDelegatingCommandHandler.stop())
+        return CompositeFuture.join(disconnectOnStop(), mappingAndDelegatingCommandHandler.stop())
                 .map((Void) null);
     }
 


### PR DESCRIPTION
This is especially needed for the `KafkaApplicationClient`, letting a given handler be invoked when the Kafka producer
is ready.
Also introduce a lifecycleStatus in `AbstractServiceClient`, preventing successive start() invocations.