### PR TITLE
[#2760] Improved handling of MQTT adapter shutdown.

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
@@ -527,9 +527,10 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
      */
     protected CommandRouterCommandConsumerFactory commandConsumerFactory(final CommandRouterClient commandRouterClient) {
 
-        LOG.debug("using Command Router service client, configuring CommandConsumerFactory [{}]",
+        LOG.debug("using Command Router service client, configuring CommandConsumerFactory [commandRouterClient: {}]",
                 CommandRouterCommandConsumerFactory.class.getName());
-        return new CommandRouterCommandConsumerFactory(commandRouterClient, getComponentName());
+        return new CommandRouterCommandConsumerFactory(commandRouterClient, getComponentName(), tracer,
+                commandRouterConfig.getBatchSize(), commandRouterConfig.getBatchMaxTimeout());
     }
 
     private ClientConfigProperties commandResponseSenderConfig() {

--- a/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/config/RequestResponseClientConfigProperties.java
+++ b/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/config/RequestResponseClientConfigProperties.java
@@ -35,10 +35,20 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
      * The maximum period of time in seconds after which cached responses are considered invalid.
      */
     public static final long MAX_RESPONSE_CACHE_TIMEOUT = 24 * 60 * 60L; // 24h
+    /**
+     * The number of pending operations that trigger their processing as part of a batch operation.
+     */
+    private static final int DEFAULT_BATCH_SIZE = 100;
+    /**
+     * The maximum period of time in milliseconds after which an operation is processed as part of a batch operation.
+     */
+    private static final long DEFAULT_BATCH_MAX_TIMEOUT = 500L;
 
     private int responseCacheMinSize = DEFAULT_RESPONSE_CACHE_MIN_SIZE;
     private long responseCacheMaxSize = DEFAULT_RESPONSE_CACHE_MAX_SIZE;
     private long responseCacheDefaultTimeout = DEFAULT_RESPONSE_CACHE_TIMEOUT;
+    private int batchSize = DEFAULT_BATCH_SIZE;
+    private long batchMaxTimeout = DEFAULT_BATCH_MAX_TIMEOUT;
 
     /**
      * Creates new properties using default values.
@@ -57,6 +67,8 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
         setResponseCacheDefaultTimeout(options.responseCacheDefaultTimeout());
         setResponseCacheMaxSize(options.responseCacheMaxSize());
         setResponseCacheMinSize(options.responseCacheMinSize());
+        setBatchSize(options.batchSize());
+        setBatchMaxTimeout(options.batchMaxTimeout());
     }
 
     /**
@@ -150,6 +162,61 @@ public class RequestResponseClientConfigProperties extends ClientConfigPropertie
             throw new IllegalArgumentException("default cache timeout must be greater than zero");
         }
         this.responseCacheDefaultTimeout = Math.min(timeout, MAX_RESPONSE_CACHE_TIMEOUT);
+    }
+
+    /**
+     * Gets the number of pending operations that trigger their processing as part of a batch operation.
+     * <p>
+     * The default value is {@link #DEFAULT_BATCH_SIZE}.
+     *
+     * @return The number of pending operations that trigger their processing as part of a batch operation.
+     */
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    /**
+     * Sets the number of pending operations that trigger their processing as part of a batch operation.
+     * <p>
+     * The default value is {@link #DEFAULT_BATCH_SIZE}.
+     *
+     * @param batchSize The number of pending operations that trigger their processing as part of a batch operation.
+     * @throws IllegalArgumentException if batchSize is &lt; 0.
+     */
+    public void setBatchSize(final int batchSize) {
+        if (batchSize < 0) {
+            throw new IllegalArgumentException("batch size could not be negative");
+        }
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Gets the maximum period of time in milliseconds after which an operation is processed as part of a batch
+     * operation.
+     * <p>
+     * The default value is {@link #DEFAULT_BATCH_MAX_TIMEOUT}.
+     *
+     * @return The maximum period of time after which an operation is processed as part of a batch operation.
+     */
+    public long getBatchMaxTimeout() {
+        return batchMaxTimeout;
+    }
+
+    /**
+     * Sets the maximum period of time in milliseconds after which an operation is processed as part of a batch
+     * operation.
+     * <p>
+     * The default value is {@link #DEFAULT_BATCH_MAX_TIMEOUT}.
+     *
+     * @param batchMaxTimeout The maximum period of time in milliseconds after which an operation is processed as part
+     *            of a batch operation.
+     * @throws IllegalArgumentException if batchTimeout is &lt; 0.
+     */
+    public void setBatchMaxTimeout(final long batchMaxTimeout) {
+        if (batchMaxTimeout < 0) {
+            throw new IllegalArgumentException("batch max timeout could not be negative");
+        }
+        this.batchMaxTimeout = batchMaxTimeout;
     }
 
     /**

--- a/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/config/RequestResponseClientOptions.java
+++ b/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/config/RequestResponseClientOptions.java
@@ -61,4 +61,21 @@ public interface RequestResponseClientOptions {
      */
     @WithDefault("600")
     long responseCacheDefaultTimeout();
+
+    /**
+     * Gets the number of pending operations that trigger their processing as part of a batch operation.
+     *
+     * @return The number of pending operations that trigger their processing as part of a batch operation.
+     */
+    @WithDefault("100")
+    int batchSize();
+
+    /**
+     * Gets the maximum period of time in milliseconds after which an operation is processed as part of a batch
+     * operation.
+     *
+     * @return The maximum period of time after which an operation is processed as part of a batch operation.
+     */
+    @WithDefault("500")
+    long batchMaxTimeout();
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandConsumer.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -33,4 +33,34 @@ public interface CommandConsumer {
      *         closed/overwritten already.
      */
     Future<Void> close(SpanContext spanContext);
+
+    /**
+     * Closes the consumer.
+     *
+     * @param sendEvent {@code true} if <em>disconnected notification</em> event should be sent.
+     * @param spanContext The span context (may be {@code null}).
+     * @return A future indicating the outcome of the operation. The future will be failed with a
+     *         {@code org.eclipse.hono.client.ServiceInvocationException} if there was an error closing
+     *         the consumer and with a {@code org.eclipse.hono.client.ClientErrorException} with
+     *         {@link java.net.HttpURLConnection#HTTP_PRECON_FAILED} if the consumer has been
+     *         closed/overwritten already.
+     */
+    default Future<Void> close(final boolean sendEvent, final SpanContext spanContext) {
+        return close(spanContext);
+    }
+
+    /**
+     * Indicates the consumer is not needed any more. The actual closing is up to the implementation.
+     *
+     * @param sendEvent {@code true} if <em>disconnected notification</em> event should be sent.
+     * @param spanContext The span context (may be {@code null}).
+     * @return A future indicating the outcome of the operation. The future will be failed with a
+     *         {@code org.eclipse.hono.client.ServiceInvocationException} if there was an error releasing the consumer
+     *         and with a {@code org.eclipse.hono.client.ClientErrorException} with
+     *         {@link java.net.HttpURLConnection#HTTP_PRECON_FAILED} if the consumer has been closed/overwritten
+     *         already.
+     */
+    default Future<Void> release(final boolean sendEvent, final SpanContext spanContext) {
+        return close(spanContext);
+    }
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandConsumerFactory.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandConsumerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -65,6 +65,46 @@ public interface CommandConsumerFactory extends Lifecycle {
             SpanContext context);
 
     /**
+     * Creates a command consumer for a device.
+     * <p>
+     * For each device only one command consumer may be active at any given time. Invoking this method multiple times
+     * with the same parameters will each time overwrite the previous entry.
+     * <p>
+     * It is the responsibility of the calling code to properly close a consumer
+     * once it is no longer needed by invoking its {@link CommandConsumer#close(SpanContext)}
+     * method.
+     *
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the consumer will be created.
+     * @param sendEvent {@code true} if <em>connected notification</em> event should be sent.
+     * @param commandHandler The handler to invoke with every command received. The handler must invoke one of the
+     *                       terminal methods of the passed in {@link CommandContext} in order to settle the command
+     *                       message transfer and finish the trace span associated with the {@link CommandContext}.
+     *                       The future returned by the handler indicates the outcome of handling the command.
+     * @param lifespan The time period in which the command consumer shall be active. Using a negative duration or
+     *                 {@code null} here is interpreted as an unlimited life span. The guaranteed granularity
+     *                 taken into account here is seconds.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *                An implementation should use this as the parent for any span it creates for tracing
+     *                the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be completed with the newly created consumer once the link
+     *         has been established.
+     *         <p>
+     *         The future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException} with an
+     *         error code indicating the cause of the failure.
+     * @throws NullPointerException if any of tenant, device ID or command handler is {@code null}.
+     */
+    Future<CommandConsumer> createCommandConsumer(
+            String tenantId,
+            String deviceId,
+            boolean sendEvent,
+            Function<CommandContext, Future<Void>> commandHandler,
+            Duration lifespan,
+            SpanContext context);
+
+    /**
      * Creates a command consumer for a device that is connected via a gateway.
      * <p>
      * For each device only one command consumer may be active at any given time. Invoking this method multiple times
@@ -100,6 +140,48 @@ public interface CommandConsumerFactory extends Lifecycle {
             String tenantId,
             String deviceId,
             String gatewayId,
+            Function<CommandContext, Future<Void>> commandHandler,
+            Duration lifespan,
+            SpanContext context);
+
+    /**
+     * Creates a command consumer for a device that is connected via a gateway.
+     * <p>
+     * For each device only one command consumer may be active at any given time. Invoking this method multiple times
+     * with the same parameters will each time overwrite the previous entry.
+     * <p>
+     * It is the responsibility of the calling code to properly close a consumer
+     * once it is no longer needed by invoking its {@link CommandConsumer#close(SpanContext)}
+     * method.
+     *
+     * @param tenantId The tenant to consume commands from.
+     * @param deviceId The device for which the consumer will be created.
+     * @param gatewayId The gateway that wants to act on behalf of the device.
+     * @param sendEvent {@code true} if <em>connected notification</em> event should be sent.
+     * @param commandHandler The handler to invoke with every command received. The handler must invoke one of the
+     *                       terminal methods of the passed in {@link CommandContext} in order to settle the command
+     *                       message transfer and finish the trace span associated with the {@link CommandContext}.
+     *                       The future returned by the handler indicates the outcome of handling the command.
+     * @param lifespan The time period in which the command consumer shall be active. Using a negative duration or
+     *                 {@code null} here is interpreted as an unlimited life span. The guaranteed granularity
+     *                 taken into account here is seconds.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *                An implementation should use this as the parent for any span it creates for tracing
+     *                the execution of this operation.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be completed with the newly created consumer once the link
+     *         has been established.
+     *         <p>
+     *         The future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException} with an error code indicating
+     *         the cause of the failure.
+     * @throws NullPointerException if any of tenant, device ID, gateway ID or command handler is {@code null}.
+     */
+    Future<CommandConsumer> createCommandConsumer(
+            String tenantId,
+            String deviceId,
+            String gatewayId,
+            boolean sendEvent,
             Function<CommandContext, Future<Void>> commandHandler,
             Duration lifespan,
             SpanContext context);

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterClient.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandRouterClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,6 +16,7 @@ package org.eclipse.hono.client.command;
 import java.time.Duration;
 import java.util.List;
 
+import org.eclipse.hono.util.CommandRouterDeviceInfo;
 import org.eclipse.hono.util.Lifecycle;
 
 import io.opentracing.SpanContext;
@@ -57,6 +58,7 @@ public interface CommandRouterClient extends Lifecycle {
      *
      * @param tenantId The tenant id.
      * @param deviceId The device id.
+     * @param sendEvent {@code true} if <em>connected notification</em> event should be sent.
      * @param adapterInstanceId The protocol adapter instance id.
      * @param lifespan The lifespan of the registration entry. Using a negative duration or {@code null} here is
      *                 interpreted as an unlimited lifespan. Only the number of seconds in the given duration
@@ -70,8 +72,8 @@ public interface CommandRouterClient extends Lifecycle {
      *         Otherwise the future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException}.
      * @throws NullPointerException if tenantId, deviceId or adapterInstanceId is {@code null}.
      */
-    Future<Void> registerCommandConsumer(String tenantId, String deviceId, String adapterInstanceId, Duration lifespan,
-            SpanContext context);
+    Future<Void> registerCommandConsumer(String tenantId, String deviceId, boolean sendEvent, String adapterInstanceId,
+            Duration lifespan, SpanContext context);
 
     /**
      * Unregisters a command consumer for a device.
@@ -80,6 +82,7 @@ public interface CommandRouterClient extends Lifecycle {
      *
      * @param tenantId The tenant id.
      * @param deviceId The device id.
+     * @param sendEvent {@code true} if <em>disconnected notification</em> event should be sent.
      * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
      * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
      *            An implementation should use this as the parent for any span it creates for tracing
@@ -90,7 +93,27 @@ public interface CommandRouterClient extends Lifecycle {
      *         Otherwise the future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException}.
      * @throws NullPointerException if any of the parameters except context is {@code null}.
      */
-    Future<Void> unregisterCommandConsumer(String tenantId, String deviceId, String adapterInstanceId, SpanContext context);
+    Future<Void> unregisterCommandConsumer(String tenantId, String deviceId, boolean sendEvent,
+            String adapterInstanceId, SpanContext context);
+
+    /**
+     * Unregisters a command consumers for batch of devices.
+     * <p>
+     * A batch registration entry is only deleted if the device is currently mapped to the given adapter instance.
+     *
+     * @param commandRouterDeviceInfos The batch of device infos.
+     * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
+     * @param context The currently active OpenTracing span context or {@code null} if no span is currently active.
+     *            An implementation should use this as the parent for any span it creates for tracing
+     *            the execution of this operation.
+      * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the consumers were successfully unregistered.
+     *         Otherwise the future will be failed with a {@code org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<Void> unregisterCommandConsumers(List<CommandRouterDeviceInfo> commandRouterDeviceInfos,
+            String adapterInstanceId, SpanContext context);
 
     /**
      * Adds tenants for which command routing should be enabled.

--- a/clients/command/src/test/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactoryTest.java
+++ b/clients/command/src/test/java/org/eclipse/hono/client/command/CommandRouterCommandConsumerFactoryTest.java
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.client.command;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -28,35 +28,57 @@ import static com.google.common.truth.Truth.assertThat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.hono.client.amqp.connection.ConnectionLifecycle;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
 import org.eclipse.hono.client.amqp.connection.ReconnectListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 
+import io.opentracing.Span;
+import io.opentracing.Tracer;
 import io.vertx.core.Future;
-
+import io.vertx.core.Vertx;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
 /**
  * Tests verifying behavior of {@link CommandRouterCommandConsumerFactory}.
  *
  */
+@ExtendWith(VertxExtension.class)
+@Timeout(value = 10, timeUnit = TimeUnit.SECONDS)
 public class CommandRouterCommandConsumerFactoryTest {
+
+    private static final int BATCH_SIZE = 100;
+    private static final int BATCH_MAX_TIMEOUT = 500;
 
     private CommandRouterClient commandRouterClient;
     private CommandRouterCommandConsumerFactory factory;
+    private Tracer tracer;
 
     /**
      * Sets up the fixture.
      */
     @BeforeEach
     void setUp() {
+        tracer = mock(Tracer.class);
+        final Tracer.SpanBuilder builder = mock(Tracer.SpanBuilder.class);
+        when(builder.addReference(any(), any())).thenReturn(builder);
+        when(builder.ignoreActiveSpan()).thenReturn(builder);
+        when(builder.withTag(anyString(), anyString())).thenReturn(builder);
+        when(builder.start()).thenReturn(mock(Span.class));
+        when(tracer.buildSpan(any())).thenReturn(builder);
+
         commandRouterClient = mock(CommandRouterClient.class, withSettings().extraInterfaces(ConnectionLifecycle.class));
-        when(commandRouterClient.registerCommandConsumer(anyString(), anyString(), anyString(), any(Duration.class), any()))
+        when(commandRouterClient.registerCommandConsumer(anyString(), anyString(), anyBoolean(), anyString(), any(Duration.class), any()))
             .thenReturn(Future.succeededFuture());
-        factory = new CommandRouterCommandConsumerFactory(commandRouterClient, "test-adapter");
+        when(commandRouterClient.unregisterCommandConsumers(any(), any(), any())).thenReturn(Future.succeededFuture());
+        factory = new CommandRouterCommandConsumerFactory(commandRouterClient, "test-adapter", tracer, BATCH_SIZE, BATCH_MAX_TIMEOUT);
     }
 
     @SuppressWarnings("unchecked")
@@ -89,5 +111,56 @@ public class CommandRouterCommandConsumerFactoryTest {
             return list.size() == 1;
         }), any());
         assertThat(enabledTenants).containsExactly("tenant1", "tenant2", "tenant3");
+    }
+
+    @Test
+    void testClosingConsumersViaLimit(final Vertx vertx, final VertxTestContext ctx) {
+
+        vertx.runOnContext(h -> {
+            // GIVEN a consumer factory with command consumers registered for 100 devices
+            final List<Future<CommandConsumer>> consumers = new ArrayList();
+            for (int i = 0; i < BATCH_SIZE; i++) {
+                consumers.add(factory.createCommandConsumer("tenant1", "device" + i, "adapter",
+                        ctx2 -> Future.succeededFuture(), Duration.ofMinutes(10), null));
+            }
+
+            // WHEN the consumers are released
+            consumers.forEach(f -> f.onComplete(r -> r.result().release(true, null)));
+
+            // THEN commandRouterClient is called to unregister BATCH_COUNT command consumers
+            ctx.verify(() -> {
+                verify(commandRouterClient).unregisterCommandConsumers(argThat(list -> {
+                    return list.size() == consumers.size();
+                }), any(), any());
+
+            });
+            ctx.completeNow();
+        });
+    }
+
+    @Test
+    void testClosingConsumersViaTimer(final Vertx vertx, final VertxTestContext ctx) {
+
+        vertx.runOnContext(event -> {
+            // GIVEN a consumer factory with command consumers registered for 1 device
+            final Future<CommandConsumer> consumer = factory.createCommandConsumer("tenant1", "device", "adapter",
+                    ctx2 -> Future.succeededFuture(), Duration.ofMinutes(10), null);
+
+            // WHEN the consumer is released
+            consumer.onComplete(f -> f.result().release(true, null));
+        });
+
+        ctx.verify(() -> {
+            // AND wait until the timer is executed
+            synchronized (ctx) {
+                ctx.wait(BATCH_MAX_TIMEOUT + 100);
+            }
+
+            // THEN commandRouterClient is called to unregister 1 command consumer
+            verify(commandRouterClient).unregisterCommandConsumers(argThat(list -> {
+                return list.size() == 1;
+            }), any(), any());
+        });
+        ctx.completeNow();
     }
 }

--- a/core/src/main/java/org/eclipse/hono/util/CommandRouterConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandRouterConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -46,6 +46,10 @@ public final class CommandRouterConstants extends RequestResponseApiConstants {
          * The <em>unregister command consumer</em> operation.
          */
         UNREGISTER_COMMAND_CONSUMER("unregister-command-consumer"),
+        /**
+         * The <em>unregister command consumers</em> operation.
+         */
+        UNREGISTER_COMMAND_CONSUMERS("unregister-command-consumers"),
         /**
          * The <em>enable command routing</em> operation.
          */

--- a/core/src/main/java/org/eclipse/hono/util/CommandRouterDeviceInfo.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandRouterDeviceInfo.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.util;
+
+import java.util.Objects;
+
+/**
+ * A CommandRouter device information holder.
+ */
+public class CommandRouterDeviceInfo {
+
+    private final String tenantId;
+    private final String deviceId;
+    private final boolean sendEvent;
+
+    private String stringRep;
+
+    private CommandRouterDeviceInfo(final String tenantId, final String deviceId, final boolean sendEvent) {
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.sendEvent = sendEvent;
+    }
+
+    /**
+     * Creates a new tenant and device pair.
+     *
+     * @param tenantId The tenantId.
+     * @param deviceId The deviceId.
+     * @param sendEvent {@code true} if <em>notification</em> event should be sent.
+     * @return The pair.
+     * @throws NullPointerException if any value is {@code null}.
+     */
+    public static CommandRouterDeviceInfo of(final String tenantId, final String deviceId, final boolean sendEvent) {
+        return new CommandRouterDeviceInfo(tenantId, deviceId, sendEvent);
+    }
+
+    /**
+     * Gets the tenant identifier.
+     *
+     * @return The identifier.
+     */
+    public String tenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Gets the device identifier.
+     *
+     * @return The identifier.
+     */
+    public String deviceId() {
+        return deviceId;
+    }
+
+
+    /**
+     * <em>notification</em> event flag.
+     *
+     * @return {@code true} if <em>connected notification</em> event should be sent.
+     */
+    public boolean sendEvent() {
+        return sendEvent;
+    }
+
+    @Override
+    public String toString() {
+        if (stringRep == null) {
+            stringRep = String.format("TenantAndDeviceId[tenantId: %s, deviceId: %s, sendEvent: %s]", tenantId,
+                    deviceId, sendEvent);
+        }
+        return stringRep;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || !(obj instanceof CommandRouterDeviceInfo)) {
+            return false;
+        }
+
+        final CommandRouterDeviceInfo other = (CommandRouterDeviceInfo) obj;
+        if (!tenantId.equals(other.tenantId)) {
+            return false;
+        }
+        if (!deviceId.equals(other.deviceId)) {
+            return false;
+        }
+
+        return sendEvent == other.sendEvent;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tenantId.hashCode();
+        result = 31 * result + deviceId.hashCode();
+        result = 31 * result + Boolean.valueOf(sendEvent).hashCode();
+        return result;
+    }
+}

--- a/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
+++ b/core/src/main/java/org/eclipse/hono/util/MessageHelper.java
@@ -89,6 +89,11 @@ public final class MessageHelper {
     public static final String APP_PROPERTY_CMD_VIA = "via";
 
     /**
+     * The name of the AMQP 1.0 message application property containing flag if connection event should be sent.
+     */
+    public static final String APP_PROPERTY_SEND_EVENT = "send_event";
+
+    /**
      * The AMQP 1.0 <em>delivery-count</em> message header property.
      */
     public static final String SYS_HEADER_PROPERTY_DELIVERY_COUNT = "delivery-count";

--- a/services/command-router/pom.xml
+++ b/services/command-router/pom.xml
@@ -49,6 +49,18 @@
       <artifactId>hono-client-notification-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-telemetry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-telemetry-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-telemetry-amqp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-caffeine</artifactId>
     </dependency>

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandRouterService.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandRouterService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,6 +16,8 @@ package org.eclipse.hono.commandrouter;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+
+import org.eclipse.hono.util.CommandRouterDeviceInfo;
 
 import io.opentracing.Span;
 import io.vertx.core.Future;
@@ -77,6 +79,7 @@ public interface CommandRouterService {
      *
      * @param tenantId The tenant id.
      * @param deviceId The device id.
+     * @param sendEvent {@code true} if <em>connected notification</em> event should be sent.
      * @param adapterInstanceId The protocol adapter instance id.
      * @param lifespan The lifespan of the mapping entry. Using a negative duration or {@code null} here is
      *                 interpreted as an unlimited lifespan. The guaranteed granularity taken into account
@@ -88,7 +91,7 @@ public interface CommandRouterService {
      *         The <em>status</em> will be <em>204 No Content</em> if the operation completed successfully.
      * @throws NullPointerException if any of the parameters except lifespan is {@code null}.
      */
-    Future<CommandRouterResult> registerCommandConsumer(String tenantId, String deviceId,
+    Future<CommandRouterResult> registerCommandConsumer(String tenantId, String deviceId, boolean sendEvent,
             String adapterInstanceId, Duration lifespan, Span span);
 
     /**
@@ -98,6 +101,7 @@ public interface CommandRouterService {
      *
      * @param tenantId The tenant id.
      * @param deviceId The device id.
+     * @param sendEvent {@code true} if <em>disconnected notification</em> event should be sent.
      * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
      * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
      *            implementation should log (error) events on this span and it may set tags and use this span as the
@@ -106,7 +110,25 @@ public interface CommandRouterService {
      *         The <em>status</em> will be <em>204 No Content</em> if the entry was successfully removed.
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
-    Future<CommandRouterResult> unregisterCommandConsumer(String tenantId, String deviceId, String adapterInstanceId, Span span);
+    Future<CommandRouterResult> unregisterCommandConsumer(String tenantId, String deviceId, boolean sendEvent,
+            String adapterInstanceId, Span span);
+
+    /**
+     * Unregisters a command consumers for batch of devices.
+     * <p>
+     * A batch registration entry is only deleted if the device is currently mapped to the given adapter instance.
+     *
+     * @param commandRouterDeviceInfo The batch of device infos.
+     * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         The <em>status</em> will be <em>204 No Content</em> if the entry was successfully removed.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<CommandRouterResult> unregisterCommandConsumers(List<CommandRouterDeviceInfo> commandRouterDeviceInfo,
+            String adapterInstanceId, Span span);
 
     /**
      * Adds tenants for which command routing should be enabled.

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -25,11 +25,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.util.MessagingClientProvider;
 import org.eclipse.hono.client.util.ServiceClient;
 import org.eclipse.hono.commandrouter.AdapterInstanceStatusService;
@@ -40,9 +42,16 @@ import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
 import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.CommandRouterDeviceInfo;
+import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.Pair;
+import org.eclipse.hono.util.QoS;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,6 +79,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
     private final TenantClient tenantClient;
     private final DeviceConnectionInfo deviceConnectionInfo;
     private final MessagingClientProvider<CommandConsumerFactory> commandConsumerFactoryProvider;
+    private final MessagingClientProvider<EventSender> eventSenderProvider;
     private final AdapterInstanceStatusService adapterInstanceStatusService;
     private final Tracer tracer;
     private final Deque<Pair<String, Integer>> tenantsToEnable = new ArrayDeque<>();
@@ -90,6 +100,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
      * @param tenantClient The tenant client.
      * @param deviceConnectionInfo The client for accessing device connection data.
      * @param commandConsumerFactoryProvider The factory provider to use for creating clients to receive commands.
+     * @param eventSenderProvider The factory provider to use for creating clients to send events.
      * @param adapterInstanceStatusService The service providing info about the status of adapter instances.
      * @param tracer The Open Tracing tracer to use for tracking processing of requests.
      * @throws NullPointerException if any of the parameters is {@code null}.
@@ -100,6 +111,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
             final TenantClient tenantClient,
             final DeviceConnectionInfo deviceConnectionInfo,
             final MessagingClientProvider<CommandConsumerFactory> commandConsumerFactoryProvider,
+            final MessagingClientProvider<EventSender> eventSenderProvider,
             final AdapterInstanceStatusService adapterInstanceStatusService,
             final Tracer tracer) {
 
@@ -108,6 +120,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
         this.tenantClient = Objects.requireNonNull(tenantClient);
         this.deviceConnectionInfo = Objects.requireNonNull(deviceConnectionInfo);
         this.commandConsumerFactoryProvider = Objects.requireNonNull(commandConsumerFactoryProvider);
+        this.eventSenderProvider = Objects.requireNonNull(eventSenderProvider);
         this.adapterInstanceStatusService = Objects.requireNonNull(adapterInstanceStatusService);
         this.tracer = Objects.requireNonNull(tracer);
     }
@@ -142,6 +155,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
                 ((Lifecycle) deviceConnectionInfo).start();
             }
             commandConsumerFactoryProvider.start();
+            eventSenderProvider.start();
             adapterInstanceStatusService.start();
         }
 
@@ -160,6 +174,7 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
             if (deviceConnectionInfo instanceof Lifecycle) {
                 results.add(((Lifecycle) deviceConnectionInfo).stop());
             }
+            results.add(eventSenderProvider.stop());
             results.add(commandConsumerFactoryProvider.stop());
             results.add(adapterInstanceStatusService.stop());
             tenantsToEnable.clear();
@@ -192,20 +207,23 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
     }
 
     @Override
-    public Future<CommandRouterResult> registerCommandConsumer(final String tenantId,
-            final String deviceId, final String adapterInstanceId, final Duration lifespan,
-            final Span span) {
+    public Future<CommandRouterResult> registerCommandConsumer(final String tenantId, final String deviceId,
+            final boolean sendEvent, final String adapterInstanceId, final Duration lifespan, final Span span) {
 
-        return tenantClient.get(tenantId, span.context())
+        final Future<TenantObject> tenantObjectFuture = tenantClient.get(tenantId, span.context());
+        return tenantObjectFuture
                 .compose(tenantObject -> {
-                    final CommandConsumerFactory primaryFactory = commandConsumerFactoryProvider.getClient(tenantObject);
-                    final Future<Void> primaryConsumerFuture = primaryFactory.createCommandConsumer(tenantId, span.context());
+                    final CommandConsumerFactory primaryFactory = commandConsumerFactoryProvider
+                            .getClient(tenantObject);
+                    final Future<Void> primaryConsumerFuture = primaryFactory.createCommandConsumer(tenantId,
+                            span.context());
 
                     if (primaryFactory.getMessagingType() == MessagingType.kafka
                             && commandConsumerFactoryProvider.getClient(MessagingType.amqp) != null) {
                         // tenant is configured to use Kafka but AMQP is also configured
                         span.log("also creating secondary, AMQP-based consumer");
-                        final Future<Void> amqpConsumerFuture = commandConsumerFactoryProvider.getClient(MessagingType.amqp)
+                        final Future<Void> amqpConsumerFuture = commandConsumerFactoryProvider
+                                .getClient(MessagingType.amqp)
                                 .createCommandConsumer(tenantId, span.context());
                         return CompositeFuture.join(primaryConsumerFuture, amqpConsumerFuture)
                                 .map(v -> (Void) null)
@@ -221,11 +239,24 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
                     return primaryConsumerFuture;
                 })
                 .compose(v -> deviceConnectionInfo
-                        .setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, getSanitizedLifespan(lifespan), span)
+                        .setCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId,
+                                getSanitizedLifespan(lifespan), span)
                         .onFailure(thr -> {
-                            LOG.info("error setting command handling adapter instance [tenant: {}, device: {}]", tenantId, deviceId, thr);
+                            LOG.info("error setting command handling adapter instance [tenant: {}, device: {}]",
+                                    tenantId, deviceId, thr);
                         }))
-                .map(v -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+                .compose(v2 -> {
+                    if (sendEvent) {
+                        return sendConnectedTtdEvent(tenantObjectFuture.result(), deviceId, adapterInstanceId,
+                                span.context()).onFailure(thr -> {
+                                    LOG.info("error sending connected Ttd event [tenant: {}, device: {}]",
+                                            tenantId, deviceId, thr);
+                                });
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                })
+                .map(v3 -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT))
                 .otherwise(t -> CommandRouterResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
 
@@ -237,16 +268,65 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
 
     @Override
     public Future<CommandRouterResult> unregisterCommandConsumer(final String tenantId, final String deviceId,
-            final String adapterInstanceId, final Span span) {
+            final boolean sendEvent, final String adapterInstanceId, final Span span) {
 
         return deviceConnectionInfo
                 .removeCommandHandlingAdapterInstance(tenantId, deviceId, adapterInstanceId, span)
-                .recover(thr -> {
+                .onFailure(thr -> {
                     if (ServiceInvocationException.extractStatusCode(thr) != HttpURLConnection.HTTP_PRECON_FAILED) {
-                        LOG.info("error removing command handling adapter instance [tenant: {}, device: {}]", tenantId, deviceId, thr);
+                        LOG.info("error removing command handling adapter instance [tenant: {}, device: {}]", tenantId,
+                                deviceId, thr);
                     }
-                    return Future.failedFuture(thr);
                 })
+                .compose(v -> {
+                    if (sendEvent) {
+                        return tenantClient.get(tenantId, span.context()).compose(
+                                tenantObject -> sendDisconnectedTtdEvent(tenantObject, deviceId, adapterInstanceId,
+                                        span.context()).onFailure(thr -> {
+                                            LOG.info("error sending disconnected Ttd event [tenant: {}, device: {}]",
+                                                    tenantId, deviceId, thr);
+                                        }));
+                    } else {
+                        return Future.succeededFuture();
+                    }
+                })
+                .map(v -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT))
+                .otherwise(t -> CommandRouterResult.from(ServiceInvocationException.extractStatusCode(t)));
+    }
+
+    @Override
+    public Future<CommandRouterResult> unregisterCommandConsumers(final List<CommandRouterDeviceInfo> commandRouterDeviceInfos,
+            final String adapterInstanceId, final Span span) {
+
+        final List<Future> unregisterFutures = commandRouterDeviceInfos.stream()
+                .map(crdi -> tenantClient.get(crdi.tenantId(), span.context())
+                        .compose(tenantObject -> deviceConnectionInfo
+                                .removeCommandHandlingAdapterInstance(crdi.tenantId(), crdi.deviceId(),
+                                        adapterInstanceId, span)
+                                .onFailure(thr -> {
+                                    if (ServiceInvocationException
+                                            .extractStatusCode(thr) != HttpURLConnection.HTTP_PRECON_FAILED) {
+                                        LOG.info(
+                                                "error removing command handling adapter instance [tenant: {}, device: {}]",
+                                                crdi.tenantId(), crdi.deviceId(), thr);
+                                    }
+                                })
+                                .compose(v -> {
+                                    if (crdi.sendEvent()) {
+                                        return sendDisconnectedTtdEvent(tenantObject, crdi.deviceId(),
+                                                adapterInstanceId,
+                                                span.context()).onFailure(thr -> {
+                                                    LOG.info(
+                                                            "error sending disconnected Ttd event [tenant: {}, device: {}]",
+                                                            crdi.tenantId(), crdi.deviceId(), thr);
+                                                });
+                                    } else {
+                                        return Future.succeededFuture();
+                                    }
+                                })))
+                .collect(Collectors.toList());
+
+        return CompositeFuture.join(unregisterFutures)
                 .map(v -> CommandRouterResult.from(HttpURLConnection.HTTP_NO_CONTENT))
                 .otherwise(t -> CommandRouterResult.from(ServiceInvocationException.extractStatusCode(t)));
     }
@@ -404,5 +484,87 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
                         procedure.tryComplete(Status.OK());
                     }
                 });
+    }
+
+    /**
+     * Sends an <em>empty notification</em> event for a device that will remain connected for an indeterminate amount of
+     * time.
+     * <p>
+     * This method invokes {@link #sendTtdEvent(TenantObject, String, String, Integer, SpanContext)} with a TTD of
+     * {@code -1}.
+     *
+     * @param tenant The tenant that the device belongs to, who owns the device.
+     * @param deviceId The device for which the TTD is reported.
+     * @param adapterInstanceId The adapter instanceId or {@code null}.
+     * @param context The currently active OpenTracing span that is used to trace the sending of the event.
+     * @return A future indicating the outcome of the operation. The future will be succeeded if the TTD event has been
+     *         sent downstream successfully. Otherwise, it will be failed with a {@link ServiceInvocationException}.
+     * @throws NullPointerException if any of tenant or device ID are {@code null}.
+     */
+    protected final Future<Void> sendConnectedTtdEvent(
+            final TenantObject tenant,
+            final String deviceId,
+            final String adapterInstanceId,
+            final SpanContext context) {
+
+        return sendTtdEvent(tenant, deviceId, adapterInstanceId, MessageHelper.TTD_VALUE_UNLIMITED, context);
+    }
+
+    /**
+     * Sends an <em>empty notification</em> event for a device that has disconnected from a protocol adapter.
+     * <p>
+     * This method invokes {@link #sendTtdEvent(TenantObject, String, String, Integer, SpanContext)} with a TTD of
+     * {@code 0}.
+     *
+     * @param tenant The tenant object that the device belongs to, who owns the device.
+     * @param deviceId The device for which the TTD is reported.
+     * @param adapterInstanceId The authenticated device or {@code null}.
+     * @param context The currently active OpenTracing span that is used to trace the sending of the event.
+     * @return A future indicating the outcome of the operation. The future will be succeeded if the TTD event has been
+     *         sent downstream successfully. Otherwise, it will be failed with a {@link ServiceInvocationException}.
+     * @throws NullPointerException if any of tenant or device ID are {@code null}.
+     */
+    protected final Future<Void> sendDisconnectedTtdEvent(
+            final TenantObject tenant,
+            final String deviceId,
+            final String adapterInstanceId,
+            final SpanContext context) {
+
+        return sendTtdEvent(tenant, deviceId, adapterInstanceId, 0, context);
+    }
+
+    private EventSender getEventSender(final TenantObject tenant) {
+        return eventSenderProvider.getClient(tenant);
+    }
+
+    private Future<Void> sendTtdEvent(
+            final TenantObject tenant,
+            final String deviceId,
+            final String adapterInstanceId,
+            final Integer ttd,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(ttd);
+
+        final Map<String, Object> props = new HashMap<>();
+        props.put(MessageHelper.APP_PROPERTY_ORIG_ADAPTER, adapterInstanceId);
+        props.put(MessageHelper.APP_PROPERTY_QOS, QoS.AT_LEAST_ONCE.ordinal());
+        props.put(CommandConstants.MSG_PROPERTY_DEVICE_TTD, ttd);
+        return getEventSender(tenant).sendEvent(
+                tenant,
+                new RegistrationAssertion(deviceId),
+                EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION,
+                null,
+                props,
+                context)
+                .onSuccess(s -> LOG.debug(
+                        "successfully sent TTD notification [tenant: {}, device-id: {}, TTD: {}]",
+                        tenant, deviceId, ttd))
+                .onFailure(t -> LOG.debug(
+                        "failed to send TTD notification [tenant: {}, device-id: {}, TTD: {}]",
+                        tenant, deviceId, ttd));
+
     }
 }

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,6 +16,7 @@ package org.eclipse.hono.commandrouter.impl;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -30,21 +31,30 @@ import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.util.MessagingClientProvider;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
 import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.CommandRouterDeviceInfo;
+import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessagingType;
+import org.eclipse.hono.util.RegistrationAssertion;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.opentracing.SpanContext;
 import io.opentracing.noop.NoopSpan;
@@ -66,6 +76,9 @@ public class CommandRouterServiceImplTest {
     private CommandRouterServiceImpl service;
     private MessagingClientProvider<CommandConsumerFactory> commandConsumerFactoryProvider;
     private CommandConsumerFactory amqpCommandConsumerFactory;
+    private MessagingClientProvider<EventSender> eventSenderProvider;
+    private DeviceConnectionInfo deviceConnectionInfo;
+    private EventSender eventSender;
     private Context context;
     private Vertx vertx;
     private TenantClient tenantClient;
@@ -82,9 +95,9 @@ public class CommandRouterServiceImplTest {
         when(tenantClient.get(anyString(), any())).thenAnswer(invocation -> {
             return Future.succeededFuture(TenantObject.from(invocation.getArgument(0)));
         });
-        final var deviceConnectionInfo = mock(DeviceConnectionInfo.class);
-        when(deviceConnectionInfo.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(), any()))
-                .thenReturn(Future.succeededFuture());
+        deviceConnectionInfo = mock(DeviceConnectionInfo.class);
+        when(deviceConnectionInfo.setCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any(),
+                any())).thenReturn(Future.succeededFuture());
         amqpCommandConsumerFactory = mock(CommandConsumerFactory.class);
         when(amqpCommandConsumerFactory.getMessagingType()).thenReturn(MessagingType.amqp);
         when(amqpCommandConsumerFactory.start()).thenReturn(Future.succeededFuture());
@@ -92,6 +105,13 @@ public class CommandRouterServiceImplTest {
         when(amqpCommandConsumerFactory.createCommandConsumer(anyString(), any())).thenReturn(Future.succeededFuture());
         commandConsumerFactoryProvider = new MessagingClientProvider<>();
         commandConsumerFactoryProvider.setClient(amqpCommandConsumerFactory);
+        eventSender = mock(EventSender.class);
+        when(eventSender.getMessagingType()).thenReturn(MessagingType.amqp);
+        when(eventSender.start()).thenReturn(Future.succeededFuture());
+        when(eventSender.stop()).thenReturn(Future.succeededFuture());
+        when(eventSender.sendEvent(any(), any(), any(), any(), any(), any())).thenReturn(Future.succeededFuture());
+        eventSenderProvider = new MessagingClientProvider<>();
+        eventSenderProvider.setClient(eventSender);
         vertx = mock(Vertx.class);
         context = VertxMockSupport.mockContext(vertx);
         when(context.owner()).thenReturn(vertx);
@@ -101,6 +121,7 @@ public class CommandRouterServiceImplTest {
                 tenantClient,
                 deviceConnectionInfo,
                 commandConsumerFactoryProvider,
+                eventSenderProvider,
                 new UnknownStatusProvidingService(),
                 NoopTracerFactory.create());
         service.setContext(context);
@@ -110,11 +131,14 @@ public class CommandRouterServiceImplTest {
     /**
      * Verifies that a command consumer gets registered in both AMQP and Kafka messaging systems if both are available
      * and the tenant is configured to use Kafka.
+     * It also checks that <em>connected notification</em> event is propagated properly.
      *
+     * @param sendEvent {@code true} if <em>connected notification</em> event should be sent.
      * @param ctx The vert.x test context.
      */
-    @Test
-    public void testRegisterCommandRouterAlsoUsingAmqpMessagingSystem(final VertxTestContext ctx) {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testRegisterCommandRouterAlsoUsingAmqpMessagingSystem(final boolean sendEvent, final VertxTestContext ctx) {
         // GIVEN a tenant configured to use a Kafka messaging system
         final String tenantId = "tenant";
         final TenantObject tenant = new TenantObject(tenantId, true);
@@ -132,7 +156,7 @@ public class CommandRouterServiceImplTest {
         when(amqpCommandConsumerFactory.createCommandConsumer(anyString(), any())).thenReturn(Future.failedFuture("expected failure"));
 
         // WHEN registering a command consumer for the tenant
-        service.registerCommandConsumer(tenantId, "deviceId", "adapterInstanceId", null, NoopSpan.INSTANCE)
+        service.registerCommandConsumer(tenantId, "deviceId", sendEvent, "adapterInstanceId", null, NoopSpan.INSTANCE)
                 .onComplete(ctx.succeeding(res -> {
                     ctx.verify(() -> {
                         // THEN both kinds of consumer clients get used
@@ -140,6 +164,144 @@ public class CommandRouterServiceImplTest {
                         verify(amqpCommandConsumerFactory).createCommandConsumer(anyString(), any());
                         // and the register operation succeeds even though the AMQP client registration failed
                         assertThat(res.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+                        if (sendEvent) {
+                            assertEmptyNotificationHasBeenSentDownstream(tenantId, "deviceId", -1);
+                        } else {
+                            assertNoEventHasBeenSentDownstream();
+                        }
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that command consumer unregister is successful and <em>disconnected notification</em> event is
+     * propagated properly.
+     *
+     * @param sendEvent {@code true} if <em>disconnected notification</em> event should be sent.
+     * @param ctx The vert.x test context.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testUnregisterCommandConsumer(final boolean sendEvent, final VertxTestContext ctx) {
+        // GIVEN a tenant configured to use a Kafka messaging system
+        final String tenantId = "tenant";
+        final TenantObject tenant = new TenantObject(tenantId, true);
+        tenant.setProperty(TenantConstants.FIELD_EXT,
+                Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.kafka.name()));
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(tenant));
+        when(deviceConnectionInfo.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Future.succeededFuture());
+
+        // WHEN unregistering a command consumer for the tenant
+        service.unregisterCommandConsumer(tenantId, "deviceId", sendEvent, "adapterInstanceId", NoopSpan.INSTANCE)
+                .onComplete(ctx.succeeding(res -> {
+                    ctx.verify(() -> {
+                        // THEN operation succeeds and ttd event is propagated properly
+                        assertThat(res.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+                        if (sendEvent) {
+                            assertEmptyNotificationHasBeenSentDownstream(tenantId, "deviceId", 0);
+                        } else {
+                            assertNoEventHasBeenSentDownstream();
+                        }
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that command consumer unregisters is successful and <em>disconnected notification</em> event is
+     * propagated properly.
+     *
+     * @param sendEvent {@code true} if <em>disconnected notification</em> event should be sent.
+     * @param ctx The vert.x test context.
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void testUnregistersCommandConsumers(final boolean sendEvent, final VertxTestContext ctx) {
+        // GIVEN a tenant configured to use a Kafka messaging system
+        final String tenantId = "tenant";
+        final TenantObject tenant = new TenantObject(tenantId, true);
+        tenant.setProperty(TenantConstants.FIELD_EXT,
+                Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.kafka.name()));
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(tenant));
+        when(deviceConnectionInfo.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Future.succeededFuture());
+
+        // WHEN unregistering a command consumers for the tenant
+        service.unregisterCommandConsumers(List.of(CommandRouterDeviceInfo.of("tenant", "deviceId", sendEvent)),
+                "adapterInstanceId", NoopSpan.INSTANCE)
+                .onComplete(ctx.succeeding(res -> {
+                    ctx.verify(() -> {
+                        // THEN operation succeeds and ttd event is propagated properly
+                        assertThat(res.getStatus()).isEqualTo(HttpURLConnection.HTTP_NO_CONTENT);
+                        if (sendEvent) {
+                            assertEmptyNotificationHasBeenSentDownstream(tenantId, "deviceId", 0);
+                        } else {
+                            assertNoEventHasBeenSentDownstream();
+                        }
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that command consumer unregisters does not send 'disconnectedTtdEvent'when removal of the command
+     * consumer mapping entry fails (which would be the case when another command consumer mapping had been registered
+     * in the meantime, meaning the device has already reconnected).
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUnregistersCommandConsumerSkipTtdEventIfRemoveConsumerFails(final VertxTestContext ctx) {
+        // GIVEN a tenant configured to use a Kafka messaging system
+        final String tenantId = "tenant";
+        final TenantObject tenant = new TenantObject(tenantId, true);
+        tenant.setProperty(TenantConstants.FIELD_EXT,
+                Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.kafka.name()));
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(tenant));
+        when(deviceConnectionInfo.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
+
+        // WHEN registering a command consumer for the tenant
+        service.unregisterCommandConsumer(tenantId, "deviceId", true,
+                "adapterInstanceId", NoopSpan.INSTANCE)
+                .onComplete(ctx.succeeding(res -> {
+                    ctx.verify(() -> {
+                        // THEN operation fails and ttd event is not propagated
+                        assertThat(res.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
+                        assertNoEventHasBeenSentDownstream();
+                    });
+                    ctx.completeNow();
+                }));
+    }
+
+    /**
+     * Verifies that command consumers unregisters does not send 'disconnectedTtdEvent'when removal of the command
+     * consumer mapping entry fails (which would be the case when another command consumer mapping had been registered
+     * in the meantime, meaning the device has already reconnected).
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testUnregistersCommandConsumersSkipTtdEventIfRemoveConsumerFails(final VertxTestContext ctx) {
+        // GIVEN a tenant configured to use a Kafka messaging system
+        final String tenantId = "tenant";
+        final TenantObject tenant = new TenantObject(tenantId, true);
+        tenant.setProperty(TenantConstants.FIELD_EXT,
+                Map.of(TenantConstants.FIELD_EXT_MESSAGING_TYPE, MessagingType.kafka.name()));
+        when(tenantClient.get(eq(tenantId), any(SpanContext.class))).thenReturn(Future.succeededFuture(tenant));
+        when(deviceConnectionInfo.removeCommandHandlingAdapterInstance(anyString(), anyString(), anyString(), any()))
+                .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED)));
+
+        // WHEN registering a command consumer for the tenant
+        service.unregisterCommandConsumers(List.of(CommandRouterDeviceInfo.of("tenant", "deviceId", true)),
+                "adapterInstanceId", NoopSpan.INSTANCE)
+                .onComplete(ctx.succeeding(res -> {
+                    ctx.verify(() -> {
+                        // THEN operation fails and ttd event is not propagated
+                        assertThat(res.getStatus()).isEqualTo(HttpURLConnection.HTTP_PRECON_FAILED);
+                        assertNoEventHasBeenSentDownstream();
                     });
                     ctx.completeNow();
                 }));
@@ -336,5 +498,47 @@ public class CommandRouterServiceImplTest {
         verify(amqpCommandConsumerFactory, never()).createCommandConsumer(anyString(), any());
         // AND no new task has been scheduled
         assertThat(eventLoop).hasSize(0);
+    }
+
+    /**
+     * Asserts that an empty notification has been sent downstream.
+     *
+     * @param tenant The tenant to check the message against.
+     * @param deviceId The device to check the message against.
+     * @param ttd The time-until-disconnect value to check the message against.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws AssertionError if no empty notification matching the given parameters has been sent.
+     */
+    protected void assertEmptyNotificationHasBeenSentDownstream(
+            final String tenant,
+            final String deviceId,
+            final Integer ttd) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(ttd);
+
+        verify(eventSender).sendEvent(
+                argThat(tenantObject -> tenantObject.getTenantId().equals(tenant)),
+                argThat(assertion -> assertion.getDeviceId().equals(deviceId)),
+                eq(EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION),
+                any(),
+                argThat(props -> ttd.equals(props.get(CommandConstants.MSG_PROPERTY_DEVICE_TTD))),
+                any());
+    }
+
+    /**
+     * Asserts that no message has been sent using the event sender.
+     *
+     * @throws AssertionError if a message has been sent.
+     */
+    protected void assertNoEventHasBeenSentDownstream() {
+        verify(eventSender, never()).sendEvent(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                anyString(),
+                any(),
+                any(),
+                any());
     }
 }

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/DelegatingCommandRouterAmqpEndpointTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/DelegatingCommandRouterAmqpEndpointTest.java
@@ -11,7 +11,6 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.commandrouter.impl;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -31,7 +30,6 @@ import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.amqp.connection.AmqpUtils;
 import org.eclipse.hono.commandrouter.CommandRouterResult;
 import org.eclipse.hono.commandrouter.CommandRouterService;
-import org.eclipse.hono.commandrouter.impl.DelegatingCommandRouterAmqpEndpoint;
 import org.eclipse.hono.util.CommandRouterConstants;
 import org.eclipse.hono.util.ResourceIdentifier;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,7 +43,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.proton.ProtonHelper;
-
 
 /**
  * Tests verifying behavior of {@link DelegatingCommandRouterAmqpEndpoint}.

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -23,6 +23,17 @@ hono:
         saslMechanism: "SCRAM-SHA-512"
         socketTimeout: 5000
         connectTimeout: 5000
+  messaging:
+    name: 'Hono Command Router'
+    host: "${hono.amqp-network.host}"
+    port: 5673
+    amqpHostname: "hono-internal"
+    keyPath: "/opt/hono/config/certs/command-router-key.pem"
+    certPath: "/opt/hono/config/certs/command-router-cert.pem"
+    trustStorePath: "/opt/hono/config/certs/trusted-certs.pem"
+    linkEstablishmentTimeout: ${link.establishment.timeout}
+    flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   registration:
     name: 'Hono Command Router'
     host: "${hono.registration.host}"

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -17,6 +17,17 @@ hono:
     cache:
       embedded:
         configurationFile: "/opt/hono/config/cache-config.xml"
+  messaging:
+    name: 'Hono Command Router'
+    host: "${hono.amqp-network.host}"
+    port: 5673
+    amqpHostname: "hono-internal"
+    keyPath: "/opt/hono/config/certs/command-router-key.pem"
+    certPath: "/opt/hono/config/certs/command-router-cert.pem"
+    trustStorePath: "/opt/hono/config/certs/trusted-certs.pem"
+    linkEstablishmentTimeout: ${link.establishment.timeout}
+    flowLatency: ${flow.latency}
+    requestTimeout: ${request.timeout}
   registration:
     name: 'Hono Command Router'
     host: "${hono.registration.host}"


### PR DESCRIPTION
Introduced unregister-cmd-consumers method at Command Router API.
That is a batch version of unregister-cmd-consumer.
The API is used only while the adapter is stopping or device is disconnected.

Signed-off-by: Nikolay Deliyski <Nikolay.Deliyski@bosch.io>