### PR TITLE
[#3222] Handle empty messages uniformly across adapters

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -1006,13 +1006,12 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
      *
      * @param contentType The indicated content type.
      * @param payload The payload from the request body.
-     * @return {@code true} if the payload is empty and the content type is
-     *         {@link EventConstants#CONTENT_TYPE_EMPTY_NOTIFICATION} or else
+     * @return {@code true} if the payload is empty and the content type is not empty, or else
      *         if the content type is not {@link EventConstants#CONTENT_TYPE_EMPTY_NOTIFICATION}.
      */
-    protected boolean isPayloadOfIndicatedType(final Buffer payload, final String contentType) {
+    public static boolean isPayloadOfIndicatedType(final Buffer payload, final String contentType) {
         if (payload == null || payload.length() == 0) {
-            return EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION.equals(contentType);
+            return !Strings.isNullOrEmpty(contentType);
         } else {
             return !EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION.equals(contentType);
         }

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBaseTest.java
@@ -353,10 +353,8 @@ public class AbstractProtocolAdapterBaseTest {
             final String contentType,
             final boolean expectedOutcome) {
 
-        adapter = newProtocolAdapter(properties, null);
-
         final Buffer body = Optional.ofNullable(payload).map(Buffer::buffer).orElse(null);
-        assertThat(adapter.isPayloadOfIndicatedType(body, contentType)).isEqualTo(expectedOutcome);
+        assertThat(AbstractProtocolAdapterBase.isPayloadOfIndicatedType(body, contentType)).isEqualTo(expectedOutcome);
     }
 
     /**

--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/AbstractHonoResource.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/AbstractHonoResource.java
@@ -28,6 +28,7 @@ import org.eclipse.californium.core.coap.MediaTypeRegistry;
 import org.eclipse.californium.core.coap.OptionSet;
 import org.eclipse.californium.core.coap.Response;
 import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.hono.adapter.AbstractProtocolAdapterBase;
 import org.eclipse.hono.auth.Device;
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
@@ -262,14 +263,10 @@ public abstract class AbstractHonoResource extends TracingSupportingHonoResource
         final String contentType = context.getContentType();
         final Buffer payload = context.getPayload();
 
-        if (contentType == null) {
+        if (!AbstractProtocolAdapterBase.isPayloadOfIndicatedType(payload, contentType)) {
             return Future.failedFuture(new ClientErrorException(
                     HttpURLConnection.HTTP_BAD_REQUEST,
-                    "request message must contain content-format option"));
-        } else if (payload.length() == 0 && !context.isEmptyNotification()) {
-            return Future.failedFuture(new ClientErrorException(
-                    HttpURLConnection.HTTP_BAD_REQUEST,
-                    "request contains no body but is not marked as empty notification"));
+                    "content type [%s] does not match payload".formatted(contentType)));
         } else {
             final String gatewayId = context.getGatewayId();
             final String tenantId = context.getOriginDevice().getTenantId();

--- a/adapters/coap/src/test/java/org/eclipse/hono/adapter/coap/AbstractHonoResourceTest.java
+++ b/adapters/coap/src/test/java/org/eclipse/hono/adapter/coap/AbstractHonoResourceTest.java
@@ -94,7 +94,7 @@ class AbstractHonoResourceTest extends ResourceTestBase {
             "false,/command_response/DEFAULT_TENANT/device_1/request_id",
             "true,/command_response//device_1/request_id"
             })
-    void getPutRequestDeviceAndAuthSucceeds(
+    void testGetPutRequestDeviceAndAuthSucceeds(
             final boolean isDeviceAuthenticated,
             final String uri,
             final VertxTestContext ctx) {
@@ -127,7 +127,7 @@ class AbstractHonoResourceTest extends ResourceTestBase {
             "true,/command_response/OTHER_TENANT/device_1/request_id,403",
             "false,/event//device_1/request_id,404"
             })
-    void getPutRequestDeviceAndAuthFailsForInvalidUri(
+    void testGetPutRequestDeviceAndAuthFailsForInvalidUri(
             final boolean isDeviceAuthenticated,
             final String uri,
             final int expectedErrorCode,

--- a/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/DownstreamAmqpMessageFactory.java
+++ b/clients/amqp-common/src/main/java/org/eclipse/hono/client/amqp/DownstreamAmqpMessageFactory.java
@@ -143,9 +143,10 @@ public final class DownstreamAmqpMessageFactory {
         addDefaults(message, props.asMap());
 
         // set default content type if none has been set yet (also after applying properties and defaults)
-        // and message payload isn't null
-        if (Strings.isNullOrEmpty(message.getContentType()) && message.getBody() != null) {
-            message.setContentType(MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+        if (Strings.isNullOrEmpty(message.getContentType())) {
+            if (message.getBody() != null) {
+                message.setContentType(MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+            }
         }
         if (addJmsVendorProps) {
             addJmsVendorProperties(message);

--- a/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/AmqpUtils.java
+++ b/clients/amqp-connection/src/main/java/org/eclipse/hono/client/amqp/connection/AmqpUtils.java
@@ -38,7 +38,6 @@ import org.eclipse.hono.client.amqp.tracing.MessageAnnotationsExtractAdapter;
 import org.eclipse.hono.client.amqp.tracing.MessageAnnotationsInjectAdapter;
 import org.eclipse.hono.util.CacheDirective;
 import org.eclipse.hono.util.CommandConstants;
-import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.ResourceIdentifier;
 
@@ -573,77 +572,33 @@ public final class AmqpUtils {
      * Sets the payload of an AMQP message using a <em>Data</em> section.
      *
      * @param message The message.
-     * @param contentType The type of the payload. A non-{@code null} type value will be used to set the
-     *                    <em>content-type</em> property of the message, if the payload is either not {@code null}
-     *                    or the {@linkplain EventConstants#CONTENT_TYPE_EMPTY_NOTIFICATION empty notification type} is
-     *                    given.
-     *                    If the given type is {@code null} and the payload is not {@code null}, the
-     *                    {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default content type} will be used.
-     * @param payload The payload or {@code null} if there is no payload to convey in the message body.
+     * @param contentType The type of the payload.
+     * @param payload The payload.
      *
      * @throws NullPointerException If message is {@code null}.
      */
     public static void setPayload(final Message message, final String contentType, final Buffer payload) {
         Objects.requireNonNull(message);
-
-        setPayload(
-                message,
-                contentType,
-                Optional.ofNullable(payload).map(Buffer::getBytes).orElse(null));
+        setPayload(message, contentType, Optional.ofNullable(payload).map(Buffer::getBytes).orElse(null));
     }
 
     /**
      * Sets the payload of an AMQP message using a <em>Data</em> section.
      *
      * @param message The message.
-     * @param contentType The type of the payload. A non-{@code null} type value will be used to set the
-     *                    <em>content-type</em> property of the message, if the payload is either not {@code null}
-     *                    or the {@linkplain EventConstants#CONTENT_TYPE_EMPTY_NOTIFICATION empty notification type} is
-     *                    given.
-     *                    If the given type is {@code null} and the payload is not {@code null}, the
-     *                    {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM default content type} will be used.
-     * @param payload The payload or {@code null} if there is no payload to convey in the message body.
+     * @param contentType The type of the payload or {@code null} if unknown.
+     * @param payload The payload or {@code null}.
      *
      * @throws NullPointerException If message is {@code null}.
      */
     public static void setPayload(final Message message, final String contentType, final byte[] payload) {
         Objects.requireNonNull(message);
 
-        setPayload(message, contentType, payload, true);
-    }
-
-    /**
-     * Sets the payload of an AMQP message using a <em>Data</em> section.
-     *
-     * @param message The message.
-     * @param contentType The type of the payload. A non-{@code null} type value will be used to set the
-     *                    <em>content-type</em> property of the message, if the payload is either not {@code null}
-     *                    or the {@linkplain EventConstants#CONTENT_TYPE_EMPTY_NOTIFICATION empty notification type} is
-     *                    given.
-     * @param payload The payload or {@code null} if there is no payload to convey in the message body.
-     * @param useDefaultContentTypeAsFallback {@code true} if the {@linkplain MessageHelper#CONTENT_TYPE_OCTET_STREAM
-     *                                        default content type} should be set if content type is {@code null} and
-     *                                        the payload is not {@code null}.
-     * @throws NullPointerException If message is {@code null}.
-     */
-    public static void setPayload(
-            final Message message,
-            final String contentType,
-            final byte[] payload,
-            final boolean useDefaultContentTypeAsFallback) {
-
-        Objects.requireNonNull(message);
-
-        if (payload != null) {
-            message.setBody(new Data(new Binary(payload)));
-        }
-        if ((payload != null && contentType != null)
-                || EventConstants.CONTENT_TYPE_EMPTY_NOTIFICATION.equals(contentType)
-                || EventConstants.CONTENT_TYPE_DEVICE_PROVISIONING_NOTIFICATION.equals(contentType)) {
-            message.setContentType(contentType);
-        } else if (payload != null && useDefaultContentTypeAsFallback) {
-            message.setContentType(MessageHelper.CONTENT_TYPE_OCTET_STREAM);
-        }
+        Optional.ofNullable(contentType).ifPresent(message::setContentType);
+        Optional.ofNullable(payload)
+            .map(Binary::new)
+            .map(Data::new)
+            .ifPresent(message::setBody);
     }
 
     /**

--- a/core/src/main/java/org/eclipse/hono/util/EventConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/EventConstants.java
@@ -47,6 +47,9 @@ public final class EventConstants {
      * The registration status of a device.
      */
     public enum RegistrationStatus {
+        /**
+         * Status indicating a newly registered device.
+         */
         NEW
     }
 

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -176,10 +176,10 @@ or rejected (unsettled).
   * (required) *to*:
     * `t`
     * `telemetry`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. Required, if the message body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -245,10 +245,10 @@ client and can then be (re-)used for sending multiple messages.
   * (required) *to*:
     * `t/${tenant-id}/${device-id}`
     * `telemetry/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. Required, if the message body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -300,10 +300,10 @@ message address is used to identify the device that the gateway publishes data f
     * `t/${tenant-id}/${device-id}`
     * `telemetry//${device-id}`
     * `telemetry/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. Required, if the message body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -350,10 +350,10 @@ All other combinations are not supported by the adapter and result in the messag
   * (required) *to*:
     * `e`
     * `event`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. Required, if the message body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -390,10 +390,10 @@ java -jar hono-cli-*-exec.jar amqp --sandbox event --payload '{"foo": "bar"}' --
   * (required) *to*:
     * `e/${tenant-id}/${device-id}`
     * `event/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. Required, if the message body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -438,10 +438,10 @@ the AMQP adapter could determine the tenant and device ID from.
     * `event//${device-id}`
     * `e/${tenant-id}/${device-id}`
     * `event/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. Required, if the message body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -176,10 +176,10 @@ or rejected (unsettled).
   * (required) *to*:
     * `t`
     * `telemetry`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
-    in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
-    message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
-    defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
+    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
+    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
+    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -245,10 +245,10 @@ client and can then be (re-)used for sending multiple messages.
   * (required) *to*:
     * `t/${tenant-id}/${device-id}`
     * `telemetry/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
-    in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
-    message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
-    defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
+    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
+    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
+    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -300,10 +300,10 @@ message address is used to identify the device that the gateway publishes data f
     * `t/${tenant-id}/${device-id}`
     * `telemetry//${device-id}`
     * `telemetry/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
-    in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
-    message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
-    defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
+    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
+    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
+    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -350,10 +350,10 @@ All other combinations are not supported by the adapter and result in the messag
   * (required) *to*:
     * `e`
     * `event`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
-    in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
-    message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
-    defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
+    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
+    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
+    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -390,10 +390,10 @@ java -jar hono-cli-*-exec.jar amqp --sandbox event --payload '{"foo": "bar"}' --
   * (required) *to*:
     * `e/${tenant-id}/${device-id}`
     * `event/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
-    in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
-    message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
-    defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
+    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
+    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
+    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -438,10 +438,10 @@ the AMQP adapter could determine the tenant and device ID from.
     * `event//${device-id}`
     * `e/${tenant-id}/${device-id}`
     * `event/${tenant-id}/${device-id}`
-  * (optional) *content-type*: The type of payload contained in the message body. The given content type will be used
-    in the AMQP message being forwarded downstream if not empty. Otherwise, the content type of the downstream
-    message will be set to `application/octet-stream` if the payload is not empty and no default content type has been
-    defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message body. The given content type, if not empty,
+    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
+    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
+    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Message Body:
   * (optional) Arbitrary payload contained in either a single AMQP *Data* or *AmqpValue* section. Note that the adapter
     only supports values of type *string* or *array* of *byte*s in the *AmqpValue* section. Values of other types will
@@ -673,7 +673,7 @@ The adapter also considers *defaults* registered for the device at either the
 [device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
 The values of the default properties are determined as follows:
 
-1. If the message already contains a non-empty property of the same name, the value if unchanged.
+1. If the message already contains a non-empty property of the same name, its value remains unchanged.
 2. Otherwise, if a default property of the same name is defined in the device's registration information,
    that value is used.
 3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,

--- a/site/documentation/content/user-guide/coap-adapter.md
+++ b/site/documentation/content/user-guide/coap-adapter.md
@@ -72,12 +72,17 @@ page lists all (currently) registered codes and the corresponding media types.
   * `CON`: *at least once* delivery semantics
   * `NON`: *at most once* delivery semantics
 * Request Options:
-  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request body is empty
+    but message is not an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+    The content type corresponding to the given content format, if not empty, will be used in the message being forwarded
+    downstream. Otherwise, the content type of the downstream message will be set to `application/octet-stream`, if the payload
+    is not empty and no default content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Query Parameters:
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
   * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
-  * (optional) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Options:
   * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
     This option will only be present if the response contains a command to be executed by the device which requires input
@@ -101,7 +106,9 @@ page lists all (currently) registered codes and the corresponding media types.
     `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
     downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
+    * The *URI-query* option contains the *empty* parameter but the request body is not empty.
+    * The request body is empty but the request has no *content-format* set nor does its
+      *URI-query* option contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -167,12 +174,17 @@ downstream application attached which could send any commands to the device.
   * `CON`: *at least once* delivery semantics
   * `NON`: *at most once* delivery semantics
 * Request Options:
-  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request body is empty
+    but message is not an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+    The content type corresponding to the given content format, if not empty, will be used in the message being forwarded
+    downstream. Otherwise, the content type of the downstream message will be set to `application/octet-stream`, if the payload
+    is not empty and no default content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Query Parameters:
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
   * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
-  * (optional) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Options:
   * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
     This option will only be present if the response contains a command to be executed by the device which requires input
@@ -196,7 +208,9 @@ downstream application attached which could send any commands to the device.
     `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
     downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
+    * The *URI-query* option contains the *empty* parameter but the request body is not empty.
+    * The request body is empty but the request has no *content-format* set nor does its
+      *URI-query* option contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -262,12 +276,17 @@ unauthenticated devices.
   * `CON`: *at least once* delivery semantics
   * `NON`: *at most once* delivery semantics
 * Request Options:
-  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request body is empty
+    but message is not an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+    The content type corresponding to the given content format, if not empty, will be used in the message being forwarded
+    downstream. Otherwise, the content type of the downstream message will be set to `application/octet-stream`, if the payload
+    is not empty and no default content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Query Parameters:
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
   * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
-  * (optional) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Options:
   * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
     This option will only be present if the response contains a command to be executed by the device which requires input
@@ -292,7 +311,9 @@ unauthenticated devices.
     `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
     downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
+    * The *URI-query* option contains the *empty* parameter but the request body is not empty.
+    * The request body is empty but the request has no *content-format* set nor does its
+      *URI-query* option contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The tenant that the gateway belongs to is not allowed to use this protocol adapter.
@@ -358,12 +379,17 @@ The example above assumes that a gateway device has been registered with `psk` c
 * Method: `POST`
 * Type:`CON`
 * Request Options:
-  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request body is empty
+    but message is not an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+    The content type corresponding to the given content format, if not empty, will be used in the message being forwarded
+    downstream. Otherwise, the content type of the downstream message will be set to `application/octet-stream`, if the payload
+    is not empty and no default content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Query Parameters:
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
   * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
-  * (optional) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Options:
   * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
     This option will only be present if the response contains a command to be executed by the device which requires input
@@ -387,7 +413,9 @@ The example above assumes that a gateway device has been registered with `psk` c
     `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
     downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
+    * The *URI-query* option contains the *empty* parameter but the request body is not empty.
+    * The request body is empty but the request has no *content-format* set nor does its
+      *URI-query* option contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -441,12 +469,17 @@ downstream application attached which could send any commands to the device.
 * Method: `PUT`
 * Type:`CON`
 * Request Options:
-  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request body is empty
+    but message is not an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+    The content type corresponding to the given content format, if not empty, will be used in the message being forwarded
+    downstream. Otherwise, the content type of the downstream message will be set to `application/octet-stream`, if the payload
+    is not empty and no default content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Query Parameters:
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
   * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
-  * (optional) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Options:
   * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
     This option will only be present if the response contains a command to be executed by the device which requires input
@@ -470,7 +503,9 @@ downstream application attached which could send any commands to the device.
     `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
     downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
+    * The *URI-query* option contains the *empty* parameter but the request body is not empty.
+    * The request body is empty but the request has no *content-format* set nor does its
+      *URI-query* option contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -524,12 +559,17 @@ unauthenticated devices.
 * Method: `PUT`
 * Type:`CON`
 * Request Options:
-  * (optional) *content-format*: The type of payload contained in the request body. Required, if request contains payload.
+  * (optional) *content-format*: The type of payload contained in the request body. Required, if request body is empty
+    but message is not an [empty notification]({{< relref "/api/event#empty-notification" >}}).
+    The content type corresponding to the given content format, if not empty, will be used in the message being forwarded
+    downstream. Otherwise, the content type of the downstream message will be set to `application/octet-stream`, if the payload
+    is not empty and no default content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Query Parameters:
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response.
   * (optional) *empty*: Marks the request as an [empty notification]({{< relref "/api/event#empty-notification" >}}).
 * Request Body:
-  * (optional) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Options:
   * (optional) *content-format*: A media type describing the semantics and format of payload contained in the response body.
     This option will only be present if the response contains a command to be executed by the device which requires input
@@ -554,7 +594,9 @@ unauthenticated devices.
     `CON` (*at least once* semantics), then the adapter waits for the message to be delivered and accepted by a
     downstream consumer before responding with this status code.
   * 4.00 (Bad Request): The request cannot be processed. Possible reasons include:
-    * the request body is empty, and the *URI-query* option doesn't contain the *empty* parameter.
+    * The *URI-query* option contains the *empty* parameter but the request body is not empty.
+    * The request body is empty but the request has no *content-format* set nor does its
+      *URI-query* option contain the *empty* parameter.
   * 4.03 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The tenant that the gateway belongs to is not allowed to use this protocol adapter.
@@ -813,7 +855,7 @@ The adapter also considers *defaults* registered for the device at either the
 [device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
 The values of the default properties are determined as follows:
 
-1. If the message already contains a non-empty property of the same name, the value if unchanged.
+1. If the message already contains a non-empty property of the same name, its value remains unchanged.
 2. Otherwise, if a default property of the same name is defined in the device's registration information,
    that value is used.
 3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,

--- a/site/documentation/content/user-guide/http-adapter.md
+++ b/site/documentation/content/user-guide/http-adapter.md
@@ -68,13 +68,17 @@ is exceeded.
   * (optional) *authorization*: The device's *auth-id* and plain text password encoded according to the
     [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the device
     to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *content-type*: The type of payload contained in the request body. Required, if the request body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content
+    type of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default
+    content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
     specified using a URI query parameter of the same name.
   * (optional) *qos-level*: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`)
     and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
 * Request Body:
-  * (required) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Headers:
   * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
@@ -97,9 +101,10 @@ is exceeded.
     potential consumer. However, if the QoS level header is set to `1` (*at least once* semantics), then the adapter
     waits for the message to be delivered and accepted by a downstream consumer before responding with this status code.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
-    * The content type header is missing.
-    * The request body is empty.
-    * The QoS header value is invalid.
+    * The request body is empty and the *content-type* header is missing.
+    * The *content-type* header indicates an [empty-notification]({{< relref "/api/event#empty-notification" >}}) but the request
+      body is not empty.
+    * The *qos-level* header value is invalid.
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
   * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
@@ -178,13 +183,17 @@ The example above assumes that the HTTP adapter is
 * URI: `/telemetry/${tenantId}/${deviceId}`
 * Method: `PUT`
 * Request Headers:
-  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *content-type*: The type of payload contained in the request body. Required, if the request body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content
+    type of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default
+    content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
     specified using a URI query parameter of the same name.
   * (optional) *qos-level*: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`)
     and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
 * Request Body:
-  * (required) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Headers:
   * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
@@ -204,9 +213,10 @@ The example above assumes that the HTTP adapter is
     potential consumer. However, if the QoS level header is set to `1` (*at least once* semantics), then the adapter
     waits for the message to be delivered and accepted by a downstream consumer before responding with this status code.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
-    * The content type header is missing.
-    * The request body is empty.
-    * The QoS header value is invalid.
+    * The request body is empty and the *content-type* header is missing.
+    * The *content-type* header indicates an [empty-notification]({{< relref "/api/event#empty-notification" >}}) but the request
+      body is not empty.
+    * The *qos-level* header value is invalid.
   * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -272,13 +282,17 @@ content-length: 23
   * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
     [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the gateway
     to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *content-type*: The type of payload contained in the request body. Required, if the request body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content
+    type of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default
+    content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
     specified using a URI query parameter of the same name.
   * (optional) *qos-level*: The QoS level for publishing telemetry messages. The adapter supports *at most once* (`0`)
     and *at least once* (`1`) QoS levels. The default value of `0` is assumed if this header is omitted.
 * Request Body:
-  * (required) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Headers:
   * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
@@ -300,9 +314,10 @@ content-length: 23
     potential consumer. However, if the QoS level header is set to `1` (*at least once* semantics), then the adapter
     waits for the message to be delivered and accepted by a downstream consumer before responding with this status code.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
-    * The content type header is missing.
-    * The request body is empty.
-    * The QoS header value is invalid.
+    * The request body is empty and the *content-type* header is missing.
+    * The *content-type* header indicates an [empty-notification]({{< relref "/api/event#empty-notification" >}}) but the request
+      body is not empty.
+    * The *qos-level* header value is invalid.
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
   * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
@@ -384,13 +399,17 @@ The example above assumes that a gateway device has been registered with `hashed
   * (optional) *authorization*: The device's *auth-id* and plain text password encoded according to the
     [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
     device to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *content-type*: The type of payload contained in the request body. Required, if the request body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content
+    type of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default
+    content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
     specified using a URI query parameter of the same name.
   * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds. Alternatively, this may be
     specified using a URI query parameter of the same name.
 * Request Body:
-  * (required) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Headers:
   * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
@@ -409,8 +428,9 @@ The example above assumes that a gateway device has been registered with `hashed
   * 200 (OK): The event has been accepted for processing. The response contains a command for the device to execute.
   * 202 (Accepted): The event has been accepted for processing.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
-    * The content type header is missing.
-    * The request body is empty but the event is not of type [empty-notification]({{< relref "/api/event#empty-notification" >}}).
+    * The request body is empty and the *content-type* header is missing.
+    * The *content-type* header indicates an [empty-notification]({{< relref "/api/event#empty-notification" >}}) but the request
+      body is not empty.
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
   * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
@@ -443,13 +463,17 @@ content-length: 0
 * URI: `/event/${tenantId}/${deviceId}`
 * Method: `PUT`
 * Request Headers:
-  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *content-type*: The type of payload contained in the request body. Required, if the request body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content
+    type of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default
+    content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
     specified using a URI query parameter of the same name.
   * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds. Alternatively, this may be
     specified using a URI query parameter of the same name.
 * Request Body:
-  * (required) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Headers:
   * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
@@ -466,8 +490,9 @@ content-length: 0
     a command for the device to execute.
   * 202 (Accepted): The event has been accepted and put to a persistent store for delivery to consumers.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
-    * The content type header is missing.
-    * The request body is empty but the event is not of type [empty-notification]({{< relref "/api/event#empty-notification" >}}).
+    * The request body is empty and the *content-type* header is missing.
+    * The *content-type* header indicates an [empty-notification]({{< relref "/api/event#empty-notification" >}}) but the request
+      body is not empty.
   * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
     * The given tenant is not allowed to use this protocol adapter.
@@ -503,13 +528,17 @@ content-length: 0
   * (optional) *authorization*: The gateway's *auth-id* and plain text password encoded according to the
     [Basic HTTP authentication scheme](https://tools.ietf.org/html/rfc7617). If not set, the adapter expects the
     gateway to present a client certificate as part of the TLS handshake during connection establishment.
-  * (required) *content-type*: The type of payload contained in the request body.
+  * (optional) *content-type*: The type of payload contained in the request body. Required, if the request body is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content
+    type of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default
+    content type has been defined for the origin device or its tenant (see
+    [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttd*: The number of seconds the device will wait for the response. Alternatively, this may be
     specified using a URI query parameter of the same name.
   * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds. Alternatively, this may be
     specified using a URI query parameter of the same name.
 * Request Body:
-  * (required) Arbitrary payload encoded according to the given content type.
+  * (optional) Arbitrary payload matching the given content type.
 * Response Headers:
   * (optional) *content-type*: A media type describing the semantics and format of payload contained in the response body.
     This header will only be present if the response contains a command to be executed by the device which requires input
@@ -528,8 +557,9 @@ content-length: 0
     contains a command for the device to execute.
   * 202 (Accepted): The event has been accepted and put to a persistent store for delivery to consumers.
   * 400 (Bad Request): The request cannot be processed. Possible reasons for this include:
-    * The content type header is missing.
-    * The request body is empty but the event is not of type [empty-notification]({{< relref "/api/event#empty-notification" >}}).
+    * The request body is empty and the *content-type* header is missing.
+    * The *content-type* header indicates an [empty-notification]({{< relref "/api/event#empty-notification" >}}) but the request
+      body is not empty.
   * 401 (Unauthorized): The request cannot be processed because the request does not contain valid credentials.
   * 403 (Forbidden): The request cannot be processed because the device's registration status cannot be asserted.
     Possible reasons for this include:
@@ -825,7 +855,7 @@ The adapter also considers *defaults* registered for the device at either the
 [device level]({{< relref "/api/device-registration#assert-device-registration" >}}).
 The values of the default properties are determined as follows:
 
-1. If the message already contains a non-empty property of the same name, the value if unchanged.
+1. If the message already contains a non-empty property of the same name, its value remains unchanged.
 2. Otherwise, if a default property of the same name is defined in the device's registration information,
    that value is used.
 3. Otherwise, if a default property of the same name is defined for the tenant that the device belongs to,

--- a/site/documentation/content/user-guide/mqtt-adapter.md
+++ b/site/documentation/content/user-guide/mqtt-adapter.md
@@ -146,10 +146,10 @@ that the message contains a JSON string:
   * `telemetry`
 * Authentication: required
 * Meta Data:
-  * (optional) *content-type*: The type of payload contained in the message payload. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message payload. Required, if the payload is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Payload:
   * (optional) Arbitrary payload. If the message has no payload, a non-empty *content-type* must be provided.
 
@@ -184,10 +184,10 @@ The example above assumes that the MQTT adapter is
   * `telemetry/${tenant-id}/${device-id}`
 * Authentication: none
 * Meta Data:
-  * (optional) *content-type*: The type of payload contained in the message payload. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message payload. Required, if the payload is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Payload:
   * (optional) Arbitrary payload. If the message has no payload, a non-empty *content-type* must be provided.
 
@@ -211,10 +211,10 @@ mosquitto_pub -t t/DEFAULT_TENANT/4711 -m '{"temp": 5}'
   * `telemetry/${tenant-id}/${device-id}`
 * Authentication: required
 * Meta Data:
-  * (optional) *content-type*: The type of payload contained in the message payload. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message payload. Required, if the payload is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
 * Payload:
   * (optional) Arbitrary payload. If the message has no payload, a non-empty *content-type* must be provided.
 
@@ -284,10 +284,10 @@ and should expire after 30 seconds:
   * `event`
 * Authentication: required
 * Meta Data:
-  * (optional) *content-type*: The type of payload contained in the message payload. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message payload. Required, if the payload is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds.
 * Payload:
   * (optional) Arbitrary payload. If the message has no payload, a non-empty *content-type* must be provided.
@@ -316,10 +316,10 @@ mosquitto_pub -u 'sensor1@DEFAULT_TENANT' -P hono-secret -t e/?hono-ttl=10 -q 1 
   * `event/${tenant-id}/${device-id}`
 * Authentication: none
 * Meta Data:
-  * (optional) *content-type*: The type of payload contained in the message payload. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message payload. Required, if the payload is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds.
 * Payload:
   * (optional) Arbitrary payload. If the message has no payload, a non-empty *content-type* must be provided.
@@ -350,10 +350,10 @@ mosquitto_pub -t e/DEFAULT_TENANT/4711/?hono-ttl=15 -q 1 -m '{"alarm": 1}'
   * `event/${tenant-id}/${device-id}`
 * Authentication: required
 * Meta Data:
-  * (optional) *content-type*: The type of payload contained in the message payload. The given content type, if not empty,
-    will be used in the message being forwarded downstream. Otherwise, the content type of the downstream message will
-    be set to `application/octet-stream`, if the payload is not empty and no default content type has been defined for the
-    origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
+  * (optional) *content-type*: The type of payload contained in the message payload. Required, if the payload is empty.
+    The given content type, if not empty, will be used in the message being forwarded downstream. Otherwise, the content type
+    of the downstream message will be set to `application/octet-stream`, if the payload is not empty and no default content type
+    has been defined for the origin device or its tenant (see [Downstream Meta Data]({{< relref "#downstream-meta-data" >}})).
   * (optional) *hono-ttl*: The message's *time-to-live* in number of seconds.
 * Payload:
   * (optional) Arbitrary payload. If the message has no payload, a non-empty *content-type* must be provided.

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,6 +16,11 @@ description = "Information about changes in recent Hono releases. Includes new f
   JSON Web Key set as defined by [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517). The Device Registry and
   Command Router components will use this endpoint to periodically download the keys if no key material has been configured
   explicitly.
+* The handling of messages that have no payload and/or no content type has been harmonized across the protocol adapters.
+  Adapters now uniformly accept messages from devices that have no payload if the device explicitly sets a non-empty content
+  type on the message. Messages with a non-empty payload can be uploaded without specifying a content type. In the messages
+  being forwarded to downstream consumers, the adapters will either use the devices's default content type, if defined, or
+  otherwise fall back to `application/octet-stream` in such cases.
 
 ### Fixes & Enhancements
 


### PR DESCRIPTION
The protocol adapters have been changed to
- accept empty telemetry and event messages from devices if the device
specifies an arbitrary non-empty content type.
- fall back to the application/octet-stream content type for non-empty
messages for which the device has not set a content type and for which
no default content type has been defined.

The adapter user guides have been adapted accordingly.

This should fix #3222