### PR TITLE
[#3345] Support building images for the arm64 platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.40.1</version>
+          <version>0.40.2</version>
           <executions>
             <execution>
               <id>build_images</id>
@@ -790,6 +790,39 @@
       <properties>
         <docker.skip.push>false</docker.skip.push>
       </properties>
+    </profile>
+    <profile>
+      <id>docker-multiarch-build</id>
+      <properties>
+        <docker.buildx.dockerStateDir>~/.docker</docker.buildx.dockerStateDir>
+        <docker.buildx.builderName>maven</docker.buildx.builderName>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>io.fabric8</groupId>
+              <artifactId>docker-maven-plugin</artifactId>
+              <configuration>
+                <images>
+                  <image>
+                    <build>
+                      <buildx>
+                        <dockerStateDir>${docker.buildx.dockerStateDir}</dockerStateDir>
+                        <builderName>${docker.buildx.builderName}</builderName>
+                        <platforms>
+                          <platform>linux/amd64</platform>
+                          <platform>linux/arm64</platform>
+                        </platforms>
+                      </buildx>
+                    </build>
+                  </image>
+                </images>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/site/documentation/content/dev-guide/building_hono.md
+++ b/site/documentation/content/dev-guide/building_hono.md
@@ -125,8 +125,31 @@ mvn clean install -Pbuild-docker-image,metrics-prometheus,docker-push-image
 ```
 
 Note that the container registry might require authentication in order to push images. The build uses the Docker Maven
-Plugin for creating and pushing images. Please refer to the [plugin documentation](http://dmp.fabric8.io/#authentication)
+Plugin for creating and pushing images. Please refer to the [plugin documentation](https://dmp.fabric8.io/#authentication)
 for details regarding how to configure credentials for the registry.
+
+#### Building Images for the arm64 Platform
+
+By default, the build process creates container images for the host system platform. For example when running the build
+on an `amd64` based system, the container images created will be for the `amd64` platform as well.
+
+Images for the `arm64` platform can, of course, be created by running the build on an `arm64` based system. However, it is also
+possible to create images for arbitrary platforms by means of [Docker's buildx command](https://docs.docker.com/build/buildx/).
+
+On Linux based hosts it is possible to use QEMU for building images for other platforms than the host system as described in this
+[blog post](https://medium.com/@nshankar_88597/building-and-testing-multi-arch-images-with-docker-buildx-and-qemu-8f72c2f8728b).
+
+Once QEMU and Docker buildx support have been set up, the `docker-multiarch-build` Maven profile can be used to build container
+images for both the `amd64` as well as the `arm64` platforms:
+
+```sh
+mvn clean install -Pbuild-docker-image,docker-multiarch-build,docker-push-image,metrics-prometheus -Ddocker.registry-name=registry.custom.org -Ddocker.image.org-name=my-repo
+```
+
+Note that the `docker-push-image` profile has been activated as well. This is necessary because buildx currently does not support
+loading multiple platform build results into the local image cache. Therefore, the created images need to be pushed to a
+container registry instead. The `docker.registry-name` and `docker.image.org-name` Maven properties can be used to set
+the (host) name of the container registry and the name of the image repository to use for the container image names.
 
 ## Running the Integration Tests
 


### PR DESCRIPTION
This is for #3345 

Use docker buildx for creating images for multiple platforms. This can be used when building the container images locally during the release process.
