### PR TITLE
Fix tracing sampler configuration

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -87,6 +87,8 @@ quarkus.micrometer.binder.kafka.enabled=false
 quarkus.micrometer.binder.system=true
 quarkus.micrometer.binder.vertx.enabled=true
 quarkus.micrometer.export.prometheus.path=/prometheus
+# Hono custom Sampler shall not be wrapped by parent-based Sampler
+quarkus.opentelemetry.tracer.sampler.parent-based=false
 quarkus.smallrye-health.root-path=${health.check.root-path}
 quarkus.smallrye-health.liveness-path=${health.check.liveness-path}
 quarkus.smallrye-health.readiness-path=${health.check.readiness-path}

--- a/service-base/src/main/java/org/eclipse/hono/service/tracing/SamplerProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tracing/SamplerProducer.java
@@ -51,11 +51,8 @@ public class SamplerProducer {
     @Produces
     Sampler sampler(final TracerRuntimeConfig tracerRuntimeConfig) {
         final TracerRuntimeConfig.SamplerConfig samplerConfig = tracerRuntimeConfig.sampler;
-        if (!tracerRuntimeConfig.suppressNonApplicationUris) {
-            LOG.info("'quarkus.opentelemetry.tracer.suppress-non-application-uris' set to 'false' - will be ignored");
-        }
-        if (!samplerConfig.parentBased) {
-            LOG.info("'quarkus.opentelemetry.tracer.sampler.parent-based' set to 'false' - will be ignored");
+        if (samplerConfig.parentBased) {
+            LOG.warn("'quarkus.opentelemetry.tracer.sampler.parent-based' set to 'true' - custom Hono Sampler will not be applied to child spans");
         }
 
         final String samplerName = Optional.ofNullable(getProperty(SAMPLER_NAME_PROPERTY))


### PR DESCRIPTION
Prevent the Hono custom Sampler (provided by the `SamplerProducer`) to be wrapped by a parent-based Sampler. Otherwise child spans (e.g. event-bus message spans) can't be dropped.

Relates to the recent Quarkus 2.12.2 update and #3416.