### PR TITLE
Vert.x event bus message related improvements

### DIFF
--- a/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationEventBusSupport.java
+++ b/clients/notification/src/main/java/org/eclipse/hono/notification/NotificationEventBusSupport.java
@@ -27,6 +27,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.tracing.TracingPolicy;
 
 /**
  * Support for sending and receiving notifications via the vert.x event bus.
@@ -97,6 +98,7 @@ public class NotificationEventBusSupport {
         final DeliveryOptions options = new DeliveryOptions();
         options.setCodecName(NOTIFICATION_EVENT_BUS_CONTAINER_LOCAL_CODEC);
         options.setLocalOnly(true);
+        options.setTracingPolicy(TracingPolicy.IGNORE);
         vertx.eventBus().publish(getEventBusAddress(notification.getType()), notification, options);
     }
 

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/EventBusAuthenticationService.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/EventBusAuthenticationService.java
@@ -37,6 +37,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.tracing.TracingPolicy;
 
 /**
  * An authentication service that verifies credentials by means of sending authentication
@@ -90,7 +91,9 @@ public final class EventBusAuthenticationService implements AuthenticationServic
     public Future<HonoUser> authenticate(final JsonObject authRequest) {
 
         final Promise<HonoUser> result = Promise.promise();
-        final DeliveryOptions options = new DeliveryOptions().setSendTimeout(AUTH_REQUEST_TIMEOUT_MILLIS);
+        final DeliveryOptions options = new DeliveryOptions();
+        options.setSendTimeout(AUTH_REQUEST_TIMEOUT_MILLIS);
+        options.setTracingPolicy(TracingPolicy.IGNORE);
         vertx.eventBus().request(AuthenticationConstants.EVENT_BUS_ADDRESS_AUTHENTICATION_IN, authRequest, options, reply -> {
             if (reply.succeeded()) {
                 final JsonObject resultBody = (JsonObject) reply.result().body();

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -39,6 +39,8 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.tracing.TracingPolicy;
 
 /**
  * Micrometer based metrics implementation.
@@ -445,7 +447,9 @@ public class MicrometerBasedMetrics implements Metrics, SendMessageSampler.Facto
         registry.find(METER_AMQP_DELIVERY_DURATION).tags(tenantTag).meters().forEach(registry::remove);
         registry.find(METER_AMQP_TIMEOUT).tags(tenantTag).meters().forEach(registry::remove);
 
-        vertx.eventBus().publish(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT, tenantId);
+        final DeliveryOptions options = new DeliveryOptions();
+        options.setTracingPolicy(TracingPolicy.IGNORE);
+        vertx.eventBus().publish(Constants.EVENT_BUS_ADDRESS_TENANT_TIMED_OUT, tenantId, options);
     }
 
     /**


### PR DESCRIPTION
Use `TracingPolicy.IGNORE` when sending event bus messages.
This is a preparation for when Quarkus takes this policy into account - see https://github.com/quarkusio/quarkus/issues/25417.

(It seems that creation of a tracing span for a _received_ event bus message can't currently be disabled. I.e. there's no equivalent to setting the `TracingPolicy` on a vert.x `HttpServer` for example.)