### PR TITLE
[#2760] Optimized AMQP adapter shutdown

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -904,58 +904,6 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
         }
     }
 
-    /**
-     * Sends an <em>empty notification</em> event for a device that will remain
-     * connected for an indeterminate amount of time.
-     * <p>
-     * This method invokes {@link #sendTtdEvent(String, String, Device, Integer, SpanContext)}
-     * with a TTD of {@code -1}.
-     *
-     * @param tenant The tenant that the device belongs to, who owns the device.
-     * @param deviceId The device for which the TTD is reported.
-     * @param authenticatedDevice The authenticated device or {@code null}.
-     * @param context The currently active OpenTracing span that is used to
-     *                trace the sending of the event.
-     * @return A future indicating the outcome of the operation. The future will be
-     *         succeeded if the TTD event has been sent downstream successfully.
-     *         Otherwise, it will be failed with a {@link ServiceInvocationException}.
-     * @throws NullPointerException if any of tenant or device ID are {@code null}.
-     */
-    protected final Future<Void> sendConnectedTtdEvent(
-            final String tenant,
-            final String deviceId,
-            final Device authenticatedDevice,
-            final SpanContext context) {
-
-        return sendTtdEvent(tenant, deviceId, authenticatedDevice, MessageHelper.TTD_VALUE_UNLIMITED, context);
-    }
-
-    /**
-     * Sends an <em>empty notification</em> event for a device that has disconnected
-     * from a protocol adapter.
-     * <p>
-     * This method invokes {@link #sendTtdEvent(String, String, Device, Integer, SpanContext)}
-     * with a TTD of {@code 0}.
-     *
-     * @param tenant The tenant that the device belongs to, who owns the device.
-     * @param deviceId The device for which the TTD is reported.
-     * @param authenticatedDevice The authenticated device or {@code null}.
-     * @param context The currently active OpenTracing span that is used to
-     *                trace the sending of the event.
-     * @return A future indicating the outcome of the operation. The future will be
-     *         succeeded if the TTD event has been sent downstream successfully.
-     *         Otherwise, it will be failed with a {@link ServiceInvocationException}.
-     * @throws NullPointerException if any of tenant or device ID are {@code null}.
-     */
-    protected final Future<Void> sendDisconnectedTtdEvent(
-            final String tenant,
-            final String deviceId,
-            final Device authenticatedDevice,
-            final SpanContext context) {
-
-        return sendTtdEvent(tenant, deviceId, authenticatedDevice, 0, context);
-    }
-
     @Override
     public final Future<Void> sendTtdEvent(
             final String tenant,

--- a/site/documentation/content/admin-guide/command-router-config.md
+++ b/site/documentation/content/admin-guide/command-router-config.md
@@ -113,6 +113,8 @@ The Command Router component uses a connection to an *AMQP 1.0 Messaging Network
   address/topic so that they can be received by protocol adapters,
 * send delivery failure command response messages in case no consumer exists for a received command (only with Kafka messaging),
 * receive notification messages about changes to tenant/device/credentials data sent from the device registry.
+* send an event message for [Time until Disconnect Notification]({{< relref "/concepts/device-notifications#time-until-disconnect-notification" >}})
+  indicating the device readiness to receive commands.
 
 Command messages are received on each configured messaging system.
 
@@ -122,8 +124,8 @@ is used.
 ### AMQP 1.0 Messaging Network Connection Configuration
 
 The connection to the *AMQP 1.0 Messaging Network* is configured according to the 
-[Hono Client Configuration]({{< relref "hono-client-configuration.md" >}}) with `HONO_COMMAND` being used as `${PREFIX}`.
-The properties for configuring response caching can be ignored.
+[Hono Client Configuration]({{< relref "hono-client-configuration.md" >}}) with `HONO_MESSAGING` and `HONO_COMMAND` being
+used as `${PREFIX}`. The properties for configuring response caching can be ignored.
 
 ### Kafka based Messaging Configuration
 

--- a/site/documentation/content/concepts/device-notifications/index.md
+++ b/site/documentation/content/concepts/device-notifications/index.md
@@ -89,18 +89,18 @@ via the HTTP protocol adapter:
 
 ### AMQP protocol adapter
 
-The AMQP protocol adapter automatically sends a *Time till disconnect notification* with a *ttd* value of `-1`
-for a device that opens a receiver link for the command source address. Please refer to the
-[AMQP Adapter user guide]({{< relref "/user-guide/amqp-adapter.md" >}}) for details).
+The AMQP protocol adapter automatically initiates sending  a *Time till disconnect notification* via the *Command Router*
+with a *ttd* value of `-1` for a device that opens a receiver link for the command source address. Please refer to the
+[AMQP Adapter user guide]({{< relref "/user-guide/amqp-adapter.md" >}}) for details.
 
-When a device closes the receiver link again, the adapter automatically sends a *Time until disconnect notification*
-with a *ttd* value of `0`.
+When a device closes the receiver link again, the adapter automatically initiates a *Time until disconnect notification*
+via the *Command Router* with a *ttd* value of `0`.
 
 ### MQTT protocol adapter
 
 The MQTT protocol adapter automatically initiates sending a *Time till disconnect notification* via the *Command Router*
 with a *ttd* value of `-1` for a device that subscribes to the appropriate command topic. Please refer to the
-[MQTT Adapter user guide]({{< relref "/user-guide/mqtt-adapter.md" >}}) for details).
+[MQTT Adapter user guide]({{< relref "/user-guide/mqtt-adapter.md" >}}) for details.
 
 When a device unsubscribes again, the adapter automatically initiates a *Time till disconnect notification* via the
 *Command Router* with a *ttd* value of `0`.

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -481,11 +481,13 @@ The AMQP adapter enables devices to receive commands that have been sent by busi
 a receiver link using a device specific *source address* as described below. When a device no longer wants to receive
 commands anymore, it can simply close the link.
 
-When a device has successfully opened a receiver link for commands, the adapter sends an
-[empty notification]({{< relref "/api/event#empty-notification" >}}) on behalf of the device to the downstream
-messaging infrastructure with the *ttd* header set to `-1`, indicating that the device will be ready to receive
-commands until further notice. Analogously, the adapter sends an empty notification with the *ttd* header set to `0`
-when a device closes the link or disconnects.
+When a device has successfully opened a receiver link for commands, the adapter initiates sending an
+[empty notification]({{< relref "/api/event#empty-notification" >}}) via the
+[Command Router]({{< relref "/api/command-router#register-command-consumer-for-device" >}}) on behalf of the device to
+the downstream messaging infrastructure with the *ttd* header set to `-1`, indicating that the device will be ready to
+receive commands until further notice. Analogously, the adapter initiates sending an empty notification via the
+ [Command Router]({{< relref "/api/command-router#unregister-command-consumer-for-device" >}}) with the *ttd* header set
+ to `0` when a device closes the link or disconnects.
 
 Devices send their responses to commands by means of sending an AMQP message with properties specific to the command
 that has been executed. The AMQP adapter accepts responses being published using either *at most once* (QoS 0) or

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,8 +16,10 @@ description = "Information about changes in recent Hono releases. Includes new f
 ### Fixes & Enhancements
 
 * Documentation for versions up to 1.11 is removed as outdated.
-* Optimized handling of MQTT / AMQP protocol adapter shutdown.
-  On shutdown, the adapter no longer explicitly unregister Command Consumers and no longer sends `disconnectedTtdEvent`.
+* Optimized handling of MQTT / AMQP protocol adapter shutdown. The purpose is removal of redundant operations for all
+  the time connected devices during adapter stop and following start. This prevents delays and possible errors due the
+  higher rate of Command Consumer unregister calls.
+  On stop, the adapter no longer explicitly unregisters Command Consumers and no longer sends `disconnectedTtdEvent`.
   The sending of `connectedTtdEvent` / `disconnectedTtdEvent` is moved from adapter to Command Router.
   Command Router config now also requires a `hono.messaging` configuration (in case AMQP messaging is used).
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,6 +16,10 @@ description = "Information about changes in recent Hono releases. Includes new f
 ### Fixes & Enhancements
 
 * Documentation for versions up to 1.11 is removed as outdated.
+* Optimized handling of MQTT / AMQP protocol adapter shutdown.
+  On shutdown, the adapter no longer explicitly unregister Command Consumers and no longer sends `disconnectedTtdEvent`.
+  The sending of `connectedTtdEvent` / `disconnectedTtdEvent` is moved from adapter to Command Router.
+  Command Router config now also requires a `hono.messaging` configuration (in case AMQP messaging is used).
 
 ## 2.1.0
 


### PR DESCRIPTION
The CommandConsumers are not closed during shutdown. Sending of connected/disconnected events is moved to CommandRouter.

Signed-off-by: Nikolay Deliyski <Nikolay.Deliyski@bosch.io>