### PR TITLE
[#2760] North bound Application triggers disconnectedTtdEvent

### DIFF
--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceConnectionInfo.java
@@ -176,4 +176,11 @@ public interface DeviceConnectionInfo {
      * @throws NullPointerException if any of the parameters is {@code null}.
      */
     Future<JsonObject> getCommandHandlingAdapterInstances(String tenantId, String deviceId, Set<String> viaGateways, Span span);
+
+    /**
+     * Sets listener to be notified when an incorrect device to adapter mapping is identified.
+     *
+     * @param deviceToAdapterMappingErrorListener The listener.
+     */
+    void setDeviceToAdapterMappingErrorListener(DeviceToAdapterMappingErrorListener deviceToAdapterMappingErrorListener);
 }

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceToAdapterMappingErrorListener.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/DeviceToAdapterMappingErrorListener.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection.infinispan.client;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+
+/**
+ * Listener notified when an incorrect device to adapter mapping is found.
+ */
+public interface DeviceToAdapterMappingErrorListener {
+
+    /**
+     * Called when an obsolete device to adapter mapping is found.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @param adapterInstanceId The adapter instance identifier.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation. The future will be succeeded if the listener is
+     *         notified successfully.
+     */
+    Future<Void> onObsoleteEntryFound(String tenantId, String deviceId, String adapterInstanceId, Span span);
+}

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -157,6 +157,10 @@ public class CommandRouterServiceImpl implements CommandRouterService, HealthChe
             adapterInstanceStatusService.start();
         }
 
+        deviceConnectionInfo.setDeviceToAdapterMappingErrorListener((tenantId, deviceId, adapterInstanceId, span) -> {
+            return sendDisconnectEventIfNeeded(tenantId, deviceId, true, adapterInstanceId, span);
+
+        });
         return Future.succeededFuture();
     }
 

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -21,6 +21,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   higher rate of Command Consumer unregister calls.
   On stop, the adapter no longer explicitly unregisters Command Consumers and no longer sends `disconnectedTtdEvent`.
   The sending of `connectedTtdEvent` / `disconnectedTtdEvent` is moved from adapter to Command Router.
+  Command Router sends `disconnectedTtdEvent` in case of command from north bound application to disconnected device,
+  that is marked as connected to adapter that was already stopped.
   Command Router config now also requires a `hono.messaging` configuration (in case AMQP messaging is used).
 
 ## 2.1.0

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -21,8 +21,9 @@ description = "Information about changes in recent Hono releases. Includes new f
   higher rate of Command Consumer unregister calls.
   On stop, the adapter no longer explicitly unregisters Command Consumers and no longer sends `disconnectedTtdEvent`.
   The sending of `connectedTtdEvent` / `disconnectedTtdEvent` is moved from adapter to Command Router.
-  Command Router sends `disconnectedTtdEvent` in case of command from north bound application to disconnected device,
-  that is marked as connected to adapter that was already stopped.
+  Command Router now sends a disconnectedTtdEvent when a command is received that is targeted at a device that got
+  disconnected (and didn't reconnect) when a protocol adapter was stopped. This happens only once - during the
+  processing of the first command.
   Command Router config now also requires a `hono.messaging` configuration (in case AMQP messaging is used).
 
 ## 2.1.0


### PR DESCRIPTION
Command Router sends disconnectedTtdEvent in case of command from north bound Application to disconnected device. This happens only if the device is marked as connected to Adapter that was already shutdown.

Signed-off-by: Nikolay Deliyski <Nikolay.Deliyski@bosch.io>