### PR TITLE
#3471 Add Pub/Sub subscriber functionality

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
@@ -386,6 +386,8 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
                 telemetrySenderProvider
                         .setClient(pubSubDownstreamSender(pubSubFactory, TelemetryConstants.TELEMETRY_ENDPOINT));
                 eventSenderProvider.setClient(pubSubDownstreamSender(pubSubFactory, EventConstants.EVENT_ENDPOINT));
+            } else {
+                LOG.error("Could not initialize Pub/Sub messaging clients, no Credentials Provider present.");
             }
         }
 

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
@@ -59,10 +59,11 @@ import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerOptions;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.client.notification.kafka.NotificationKafkaConsumerConfigProperties;
-import org.eclipse.hono.client.pubsub.CachingPubSubPublisherFactory;
 import org.eclipse.hono.client.pubsub.PubSubConfigProperties;
-import org.eclipse.hono.client.pubsub.PubSubPublisherFactory;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
 import org.eclipse.hono.client.pubsub.PubSubPublisherOptions;
+import org.eclipse.hono.client.pubsub.publisher.CachingPubSubPublisherFactory;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
 import org.eclipse.hono.client.registry.CredentialsClient;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.client.registry.TenantClient;
@@ -92,6 +93,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.api.gax.core.FixedCredentialsProvider;
 
 import io.smallrye.config.ConfigMapping;
 import io.vertx.core.CompositeFuture;
@@ -372,16 +374,19 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
                             protocolAdapterProperties.isJmsVendorPropsEnabled()));
         }
         if (!appConfig.isPubSubMessagingDisabled() && pubSubConfigProperties.isProjectIdConfigured()) {
-            LOG.info("Pub/Sub client configuration present, adding Pub/Sub messaging clients");
+            final Optional<FixedCredentialsProvider> credentialsProvider = PubSubMessageHelper.getCredentialsProvider();
+            if (credentialsProvider.isPresent()) {
+                LOG.info("Pub/Sub client configuration present, adding Pub/Sub messaging clients");
 
-            final var pubSubFactory = new CachingPubSubPublisherFactory(
-                    vertx,
-                    pubSubConfigProperties.getProjectId(),
-                    null);
+                final var pubSubFactory = new CachingPubSubPublisherFactory(
+                        vertx,
+                        pubSubConfigProperties.getProjectId(),
+                        credentialsProvider.get());
 
-            telemetrySenderProvider
-                    .setClient(pubSubDownstreamSender(pubSubFactory, TelemetryConstants.TELEMETRY_ENDPOINT));
-            eventSenderProvider.setClient(pubSubDownstreamSender(pubSubFactory, EventConstants.EVENT_ENDPOINT));
+                telemetrySenderProvider
+                        .setClient(pubSubDownstreamSender(pubSubFactory, TelemetryConstants.TELEMETRY_ENDPOINT));
+                eventSenderProvider.setClient(pubSubDownstreamSender(pubSubFactory, EventConstants.EVENT_ENDPOINT));
+            }
         }
 
         final MessagingClientProviders messagingClientProviders = new MessagingClientProviders(

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/AbstractPubSubBasedMessageSender.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/AbstractPubSubBasedMessageSender.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherClient;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
 import org.eclipse.hono.client.util.ServiceClient;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.Lifecycle;

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.pubsub.v1.stub.PublisherStubSettings;
+
+/**
+ * Utility methods for working with Pub/Sub.
+ */
+public final class PubSubMessageHelper {
+
+    private PubSubMessageHelper() {
+    }
+
+    /**
+     * Gets the provider for credentials to use for authenticating to the Pub/Sub service.
+     *
+     * @return An optional containing a FixedCredentialsProvider to use for authenticating to the Pub/Sub service or an
+     *         empty optional if the given GoogleCredentials is {@code null}.
+     */
+    public static Optional<FixedCredentialsProvider> getCredentialsProvider() {
+        return Optional.ofNullable(getCredentials())
+                .map(FixedCredentialsProvider::create);
+    }
+
+    private static GoogleCredentials getCredentials() {
+        try {
+            return GoogleCredentials.getApplicationDefault()
+                    .createScoped(PublisherStubSettings.getDefaultServiceScopes());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Gets the topic name with the given prefix.
+     *
+     * @param topic The endpoint of the topic (e.g. event)
+     * @param prefix The prefix of the Pub/Sub topic, it's either the tenant ID or the adapter instance ID
+     * @return The topic containing the prefix identifier and the endpoint.
+     */
+    public static String getTopicName(final String topic, final String prefix) {
+        return String.format("%s.%s", prefix, topic);
+    }
+
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherClient.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherClient.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.hono.client.pubsub;
+package org.eclipse.hono.client.pubsub.publisher;
 
 import com.google.pubsub.v1.PubsubMessage;
 

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherClientImpl.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherClientImpl.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.hono.client.pubsub;
+package org.eclipse.hono.client.pubsub.publisher;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherFactory.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.hono.client.pubsub;
+package org.eclipse.hono.client.pubsub.publisher;
 
 import java.util.Optional;
 
@@ -27,11 +27,11 @@ public interface PubSubPublisherFactory {
      * This method is expected to be invoked as soon as the publisher is no longer needed.
      *
      * @param topic The topic of the publisher to remove.
-     * @param tenantId The tenantId of the publisher to remove.
+     * @param prefix The prefix of the topic of the publisher to remove, e.g. the tenantId.
      * @return A future that is completed when the close operation completed or a succeeded future if no publisher
      *         existed with the given topic.
      */
-    Future<Void> closePublisher(String topic, String tenantId);
+    Future<Void> closePublisher(String topic, String prefix);
 
     /**
      * Closes all cached publisher.
@@ -53,18 +53,18 @@ public interface PubSubPublisherFactory {
      * <p>
      *
      * @param topic The topic to create the publisher for.
-     * @param tenantId The tenantId to use.
+     * @param prefix The prefix of the topic of the publisher to remove, e.g. the tenantId.
      * @return an existing or new publisher.
      */
-    PubSubPublisherClient getOrCreatePublisher(String topic, String tenantId);
+    PubSubPublisherClient getOrCreatePublisher(String topic, String prefix);
 
     /**
      * Gets an existing Publisher for sending data to Pub/Sub if one was already created with the given topicName and
-     * TenantId.
+     * prefix.
      *
      * @param topic The topic to identify the publisher.
-     * @param tenantId The tenantId to identify the publisher.
+     * @param prefix The prefix of the topic to identify the publisher, e.g. the tenantId.
      * @return An existing publisher or an empty Optional if no such publisher exists.
      */
-    Optional<PubSubPublisherClient> getPublisher(String topic, String tenantId);
+    Optional<PubSubPublisherClient> getPublisher(String topic, String prefix);
 }

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactory.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.subscriber;
+
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating PubSubSubscribers. Created subscribers are being cached.
+ */
+public class CachingPubSubSubscriberFactory implements PubSubSubscriberFactory {
+
+    private final Map<String, PubSubSubscriber> activeSubscribers = new ConcurrentHashMap<>();
+    private final String projectId;
+    private final FixedCredentialsProvider credentialsProvider;
+    private Supplier<PubSubSubscriber> clientSupplier;
+
+    /**
+     * Creates a new factory for {@link PubSubSubscriber} instances.
+     *
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param credentialsProvider The provider for credentials to use for authenticating to the Pub/Sub service.
+     * @throws NullPointerException If any of the parameters is {@code null}.
+     */
+    public CachingPubSubSubscriberFactory(final String projectId, final FixedCredentialsProvider credentialsProvider) {
+        this.projectId = Objects.requireNonNull(projectId);
+        this.credentialsProvider = Objects.requireNonNull(credentialsProvider);
+    }
+
+    /**
+     * Sets a supplier for the subscriber(s) this factory creates.
+     * <p>
+     * This method is mainly intended to be used in test cases.
+     *
+     * @param supplier The supplier.
+     */
+    public void setClientSupplier(final Supplier<PubSubSubscriber> supplier) {
+        this.clientSupplier = supplier;
+    }
+
+    @Override
+    public Future<Void> closeSubscriber(final String subscription, final String prefix) {
+        final String subscriptionId = PubSubMessageHelper.getTopicName(subscription, prefix);
+        return removeSubscriber(subscriptionId);
+    }
+
+    @Override
+    public Future<Void> closeAllSubscriber() {
+        activeSubscribers.forEach((k, v) -> removeSubscriber(k));
+        if (activeSubscribers.isEmpty()) {
+            return Future.succeededFuture();
+        }
+        return Future.failedFuture(
+                new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE, "Failed to close all subscriber"));
+    }
+
+    @Override
+    public PubSubSubscriber getOrCreateSubscriber(final String subscriptionId, final MessageReceiver receiver) {
+        return activeSubscribers.computeIfAbsent(subscriptionId,
+                s -> createPubSubSubscriber(subscriptionId, receiver));
+    }
+
+    @Override
+    public Optional<PubSubSubscriber> getSubscriber(final String subscription, final String prefix) {
+        final String subscriptionId = PubSubMessageHelper.getTopicName(subscription, prefix);
+        return Optional.ofNullable(activeSubscribers.get(subscriptionId));
+    }
+
+    private PubSubSubscriber createPubSubSubscriber(final String subscriptionId,
+            final MessageReceiver receiver) {
+        return Optional.ofNullable(clientSupplier)
+                .map(Supplier::get)
+                .orElseGet(() -> new PubSubSubscriber(projectId, subscriptionId, receiver, credentialsProvider));
+    }
+
+    private Future<Void> removeSubscriber(final String subscriptionId) {
+        final var subscriber = activeSubscribers.remove(subscriptionId);
+        if (subscriber != null) {
+            try {
+                subscriber.close();
+            } catch (final Exception e) {
+                // ignore , since there is nothing we can do about it
+            }
+        }
+        return Future.succeededFuture();
+    }
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriber.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriber.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.subscriber;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * A client for receiving messages from Pub/Sub.
+ * <p>
+ * Wraps a Pub/Sub Subscriber.
+ * </p>
+ */
+public class PubSubSubscriber implements AutoCloseable {
+
+    private final Logger log = LoggerFactory.getLogger(PubSubSubscriber.class);
+    private final Subscriber subscriber;
+
+    /**
+     * Creates a new instance of PubSubSubscriberClient where a Pub/Sub Subscriber is initialized. The Subscriber is
+     * based on a created subscription, which follows the format: projects/{project}/subscriptions/{subscription}
+     *
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param subscriptionId The name of the subscription to create the subscriber for.
+     * @param receiver The message receiver used to process the received message.
+     * @param credentialsProvider The provider for credentials to use for authenticating to the Pub/Sub service.
+     * @throws NullPointerException If any of these parameters is {@code null}.
+     */
+    public PubSubSubscriber(
+            final String projectId,
+            final String subscriptionId,
+            final MessageReceiver receiver,
+            final FixedCredentialsProvider credentialsProvider) {
+        Objects.requireNonNull(projectId);
+        Objects.requireNonNull(subscriptionId);
+        Objects.requireNonNull(receiver);
+        Objects.requireNonNull(credentialsProvider);
+
+        final ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, subscriptionId);
+        this.subscriber = Subscriber
+                .newBuilder(subscriptionName, receiver)
+                .setCredentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    /**
+     * Subscribes messages from Pub/Sub.
+     *
+     * @return A future indicating the outcome of the operation.
+     * @throws ServerErrorException If subscribing was not successful.
+     */
+    public Future<Void> subscribe() {
+        try {
+            subscriber.addListener(
+                    new Subscriber.Listener() {
+
+                        @Override
+                        public void failed(final Subscriber.State from, final Throwable failure) {
+                            log.error("Error subscribing message from Pub/Sub", failure);
+                            throw new ServerErrorException(HttpURLConnection.HTTP_UNAVAILABLE,
+                                    "Error subscribing message from Pub/Sub", failure);
+                        }
+                    },
+                    MoreExecutors.directExecutor());
+            subscriber.startAsync().awaitRunning();
+            return Future.succeededFuture();
+        } catch (IllegalStateException e) {
+            log.error("Service reached illegal state", e);
+            return Future.failedFuture(e);
+        }
+    }
+
+    /**
+     * Shuts the subscriber down and frees resources.
+     */
+    @Override
+    public void close() {
+        final Context currentContext = Vertx.currentContext();
+        if (currentContext == null) {
+            throw new IllegalStateException("Client is not running on a Vert.x Context");
+        } else {
+            currentContext.executeBlocking(blockingHandler -> {
+                if (subscriber != null) {
+                    subscriber.stopAsync();
+                    blockingHandler.complete();
+                }
+            });
+        }
+    }
+
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberClient.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberClient.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.subscriber;
+
+import io.vertx.core.Future;
+
+/**
+ * A client for receiving messages from Pub/Sub.
+ * <p>
+ * Wraps a Pub/Sub Subscriber.
+ * </p>
+ */
+public interface PubSubSubscriberClient extends AutoCloseable {
+
+    /**
+     * Subscribes messages from Pub/Sub.
+     *
+     * @param keepTrying Condition that controls whether another attempt to subscribe to a subscription should be
+     *            started. Client code can set this to {@code false} in order to prevent further attempts.
+     * @return A future indicating the outcome of the operation.
+     */
+    Future<Void> subscribe(boolean keepTrying);
+
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberClientImpl.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberClientImpl.java
@@ -92,7 +92,7 @@ public class PubSubSubscriberClientImpl implements PubSubSubscriberClient {
             resultPromise.complete();
         } catch (Exception e) {
             if (keepTrying) {
-                log.error("Error subscribing message from Pub/Sub, will retry in {}ms: ", SUBSCRIBE_RETRY_DELAY_MILLIS,
+                log.info("Error subscribing message from Pub/Sub, will retry in {}ms: ", SUBSCRIBE_RETRY_DELAY_MILLIS,
                         e);
                 vertx.setTimer(SUBSCRIBE_RETRY_DELAY_MILLIS, tid -> subscribeWithRetries(resultPromise, keepTrying));
             } else {

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberFactory.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.subscriber;
+
+import java.util.Optional;
+
+import com.google.cloud.pubsub.v1.MessageReceiver;
+
+import io.vertx.core.Future;
+
+/**
+ * A factory for creating Pub/Sub subscribers scoped to a Google Cloud Project.
+ */
+public interface PubSubSubscriberFactory {
+
+    /**
+     * Closes the subscriber with the given topic if it exists.
+     * <p>
+     * This method is expected to be invoked as soon as the subscriber is no longer needed.
+     *
+     * @param subscription The subscription of the subscriber to remove.
+     * @param prefix The prefix of the topic of the subscriber to remove, e.g. the tenantId.
+     * @return A future that is completed when the close operation completed or a succeeded future if no subscriber
+     *         existed with the given topic.
+     */
+    Future<Void> closeSubscriber(String subscription, String prefix);
+
+    /**
+     * Closes all cached subscriber. This method is expected to be invoked especially before the application shuts down.
+     *
+     * @return A future that is succeeded when all subscriber are closed or a failed future if any subscriber can not be
+     *         closed.
+     */
+    Future<Void> closeAllSubscriber();
+
+    /**
+     * Gets a subscriber for receiving data from Pub/Sub.
+     * <p>
+     * The subscriber returned may be either newly created or it may be an existing subscriber for the given
+     * subscription.
+     *
+     * @param subscriptionId The subscription to create the subscriber for.
+     * @param receiver The message receiver used to process the received message.
+     * @return an existing or new subscriber.
+     */
+    PubSubSubscriber getOrCreateSubscriber(String subscriptionId, MessageReceiver receiver);
+
+    /**
+     * Gets an existing Subscriber for receiving data from Pub/Sub if one was already created with the given
+     * subscription and prefix.
+     *
+     * @param subscription The subscription to identify the subscriber.
+     * @param prefix The prefix of the subscription to identify the subscriber, e.g. the tenantId.
+     * @return An existing subscriber or an empty Optional if no such subscriber exists.
+     */
+    Optional<PubSubSubscriber> getSubscriber(String subscription, String prefix);
+
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/subscriber/PubSubSubscriberFactory.java
@@ -41,7 +41,7 @@ public interface PubSubSubscriberFactory {
      * @return A future that is succeeded when all subscriber are closed or a failed future if any subscriber can not be
      *         closed.
      */
-    Future<Void> closeAllSubscriber();
+    Future<Void> closeAllSubscribers();
 
     /**
      * Gets a subscriber for receiving data from Pub/Sub.
@@ -53,7 +53,7 @@ public interface PubSubSubscriberFactory {
      * @param receiver The message receiver used to process the received message.
      * @return an existing or new subscriber.
      */
-    PubSubSubscriber getOrCreateSubscriber(String subscriptionId, MessageReceiver receiver);
+    PubSubSubscriberClient getOrCreateSubscriber(String subscriptionId, MessageReceiver receiver);
 
     /**
      * Gets an existing Subscriber for receiving data from Pub/Sub if one was already created with the given
@@ -63,6 +63,6 @@ public interface PubSubSubscriberFactory {
      * @param prefix The prefix of the subscription to identify the subscriber, e.g. the tenantId.
      * @return An existing subscriber or an empty Optional if no such subscriber exists.
      */
-    Optional<PubSubSubscriber> getSubscriber(String subscription, String prefix);
+    Optional<PubSubSubscriberClient> getSubscriber(String subscription, String prefix);
 
 }

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/AbstractPubSubBasedMessageSenderTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/AbstractPubSubBasedMessageSenderTest.java
@@ -25,6 +25,8 @@ import java.util.Random;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherClient;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the generic behavior of {@link PubSubMessageHelper}.
+ */
+public class PubSubMessageHelperTest {
+
+    /**
+     * Verifies that the getTopicName method returns the formatted topic.
+     */
+    @Test
+    public void testThatGetTopicNameReturnsFormattedString() {
+        final String topic = "event";
+        final String prefix = "testTenant";
+
+        final String result = PubSubMessageHelper.getTopicName(topic, prefix);
+        assertThat(result).isEqualTo("testTenant.event");
+    }
+
+}

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactoryTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactoryTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.hono.client.pubsub;
+package org.eclipse.hono.client.pubsub.publisher;
 
 import static org.mockito.Mockito.mock;
 
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.Vertx;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
 
 /**
  * Verifies behavior of {@link CachingPubSubPublisherFactory}.
@@ -42,7 +44,8 @@ public class CachingPubSubPublisherFactoryTest {
     void setUp() {
         vertx = mock(Vertx.class);
         client = mock(PubSubPublisherClient.class);
-        factory = new CachingPubSubPublisherFactory(vertx, PROJECT_ID, null);
+        final FixedCredentialsProvider credentialsProvider = mock(FixedCredentialsProvider.class);
+        factory = new CachingPubSubPublisherFactory(vertx, PROJECT_ID, credentialsProvider);
         factory.setClientSupplier(() -> client);
     }
 

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactoryTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactoryTest.java
@@ -21,9 +21,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.vertx.core.Vertx;
-
 import com.google.api.gax.core.FixedCredentialsProvider;
+
+import io.vertx.core.Vertx;
 
 /**
  * Verifies behavior of {@link CachingPubSubPublisherFactory}.

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactoryTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactoryTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.CredentialsProvider;
 
 import io.vertx.core.Vertx;
 
@@ -44,7 +44,7 @@ public class CachingPubSubPublisherFactoryTest {
     void setUp() {
         vertx = mock(Vertx.class);
         client = mock(PubSubPublisherClient.class);
-        final FixedCredentialsProvider credentialsProvider = mock(FixedCredentialsProvider.class);
+        final CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
         factory = new CachingPubSubPublisherFactory(vertx, PROJECT_ID, credentialsProvider);
         factory.setClientSupplier(() -> client);
     }

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactoryTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactoryTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.CredentialsProvider;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 
 import io.vertx.core.Vertx;
@@ -38,17 +38,17 @@ public class CachingPubSubSubscriberFactoryTest {
     private static final String TOPIC_NAME = "command";
 
     private CachingPubSubSubscriberFactory factory;
-    private PubSubSubscriber client;
+    private PubSubSubscriberClient client;
     private String topic;
     private MessageReceiver receiver;
 
     @BeforeEach
     void setUp() {
         final Vertx vertx = mock(Vertx.class);
-        final FixedCredentialsProvider credentialsProvider = mock(FixedCredentialsProvider.class);
+        final CredentialsProvider credentialsProvider = mock(CredentialsProvider.class);
         topic = String.format("%s.%s", TENANT_ID, TOPIC_NAME);
         receiver = mock(MessageReceiver.class);
-        client = mock(PubSubSubscriber.class);
+        client = mock(PubSubSubscriberClient.class);
         factory = new CachingPubSubSubscriberFactory(vertx, PROJECT_ID, credentialsProvider);
         factory.setClientSupplier(() -> client);
     }
@@ -59,8 +59,8 @@ public class CachingPubSubSubscriberFactoryTest {
     @Test
     public void testThatSubscriberIsAddedToCache() {
         assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
-        final PubSubSubscriber createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
-        final Optional<PubSubSubscriber> actual = factory.getSubscriber(TOPIC_NAME, TENANT_ID);
+        final PubSubSubscriberClient createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
+        final Optional<PubSubSubscriberClient> actual = factory.getSubscriber(TOPIC_NAME, TENANT_ID);
         assertThat(actual.isPresent()).isTrue();
         assertThat(actual.get()).isEqualTo(createdSubscriber);
     }
@@ -72,7 +72,7 @@ public class CachingPubSubSubscriberFactoryTest {
     public void testCloseSubscriberClosesAndRemovesFromCache() {
         assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
 
-        final PubSubSubscriber createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
+        final PubSubSubscriberClient createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
         assertThat(createdSubscriber).isNotNull();
         assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isPresent()).isTrue();
 
@@ -87,11 +87,11 @@ public class CachingPubSubSubscriberFactoryTest {
     public void testCloseAllSubscriberClosesAndRemovesFromCache() {
         assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
 
-        final PubSubSubscriber createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
+        final PubSubSubscriberClient createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
         assertThat(createdSubscriber).isNotNull();
         assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isPresent()).isTrue();
 
-        factory.closeAllSubscriber();
+        factory.closeAllSubscribers();
         assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
     }
 }

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactoryTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactoryTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 
+import io.vertx.core.Vertx;
+
 /**
  * Verifies behavior of {@link CachingPubSubSubscriberFactory}.
  */
@@ -42,11 +44,12 @@ public class CachingPubSubSubscriberFactoryTest {
 
     @BeforeEach
     void setUp() {
+        final Vertx vertx = mock(Vertx.class);
         final FixedCredentialsProvider credentialsProvider = mock(FixedCredentialsProvider.class);
         topic = String.format("%s.%s", TENANT_ID, TOPIC_NAME);
         receiver = mock(MessageReceiver.class);
         client = mock(PubSubSubscriber.class);
-        factory = new CachingPubSubSubscriberFactory(PROJECT_ID, credentialsProvider);
+        factory = new CachingPubSubSubscriberFactory(vertx, PROJECT_ID, credentialsProvider);
         factory.setClientSupplier(() -> client);
     }
 

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactoryTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/subscriber/CachingPubSubSubscriberFactoryTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.subscriber;
+
+import static org.mockito.Mockito.mock;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+
+/**
+ * Verifies behavior of {@link CachingPubSubSubscriberFactory}.
+ */
+public class CachingPubSubSubscriberFactoryTest {
+
+    private static final String PROJECT_ID = "test-project";
+
+    private static final String TENANT_ID = "test-tenant";
+
+    private static final String TOPIC_NAME = "command";
+
+    private CachingPubSubSubscriberFactory factory;
+    private PubSubSubscriber client;
+    private String topic;
+    private MessageReceiver receiver;
+
+    @BeforeEach
+    void setUp() {
+        final FixedCredentialsProvider credentialsProvider = mock(FixedCredentialsProvider.class);
+        topic = String.format("%s.%s", TENANT_ID, TOPIC_NAME);
+        receiver = mock(MessageReceiver.class);
+        client = mock(PubSubSubscriber.class);
+        factory = new CachingPubSubSubscriberFactory(PROJECT_ID, credentialsProvider);
+        factory.setClientSupplier(() -> client);
+    }
+
+    /**
+     * Verifies that the factory creates a subscriber and adds it to the cache.
+     */
+    @Test
+    public void testThatSubscriberIsAddedToCache() {
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
+        final PubSubSubscriber createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
+        final Optional<PubSubSubscriber> actual = factory.getSubscriber(TOPIC_NAME, TENANT_ID);
+        assertThat(actual.isPresent()).isTrue();
+        assertThat(actual.get()).isEqualTo(createdSubscriber);
+    }
+
+    /**
+     * Verifies that the factory removes a subscriber from the cache when it gets closed.
+     */
+    @Test
+    public void testCloseSubscriberClosesAndRemovesFromCache() {
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
+
+        final PubSubSubscriber createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
+        assertThat(createdSubscriber).isNotNull();
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isPresent()).isTrue();
+
+        factory.closeSubscriber(TOPIC_NAME, TENANT_ID);
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
+    }
+
+    /**
+     * Verifies that the factory closes all active subscribers and removes them from the cache.
+     */
+    @Test
+    public void testCloseAllSubscriberClosesAndRemovesFromCache() {
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
+
+        final PubSubSubscriber createdSubscriber = factory.getOrCreateSubscriber(topic, receiver);
+        assertThat(createdSubscriber).isNotNull();
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isPresent()).isTrue();
+
+        factory.closeAllSubscriber();
+        assertThat(factory.getSubscriber(TOPIC_NAME, TENANT_ID).isEmpty()).isTrue();
+    }
+}

--- a/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
+++ b/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.client.pubsub.AbstractPubSubBasedMessageSender;
-import org.eclipse.hono.client.pubsub.PubSubPublisherFactory;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
 import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.telemetry.TelemetrySender;
 import org.eclipse.hono.client.util.DownstreamMessageProperties;

--- a/clients/telemetry-pubsub/src/test/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSenderTest.java
+++ b/clients/telemetry-pubsub/src/test/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSenderTest.java
@@ -24,8 +24,8 @@ import static com.google.common.truth.Truth.assertThat;
 import java.util.Map;
 
 import org.eclipse.hono.client.ServerErrorException;
-import org.eclipse.hono.client.pubsub.PubSubPublisherClient;
-import org.eclipse.hono.client.pubsub.PubSubPublisherFactory;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherClient;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
 import org.eclipse.hono.test.TracingMockSupport;
 import org.eclipse.hono.util.MessageHelper;
 import org.eclipse.hono.util.QoS;

--- a/site/documentation/content/admin-guide/pubsub-config.md
+++ b/site/documentation/content/admin-guide/pubsub-config.md
@@ -15,13 +15,14 @@ To authenticate to the Google Pub/Sub API, Workload Identity is used and has to 
 Support for Google Pub/Sub based messaging infrastructure is considered **experimental** and may change without further notice.
 {{% /notice %}}
 
-## Publisher Configuration
+## Publisher and Subscriber Configuration
 
-The `org.eclipse.hono.client.pubsub.CachingPubSubPublisherFactory` factory can be used to create Pub/Sub publishers for Hono's
-Pub/Sub based APIs.
+The `org.eclipse.hono.client.pubsub.publisher.CachingPubSubPublisherFactory` factory can be used to create Pub/Sub
+publishers for Hono's Pub/Sub based APIs. The `org.eclipse.hono.client.pubsub.subscriber.CachingPubSubSubscriberFactory`
+factory can be used to create Pub/Sub subscribers for Hono's Pub/Sub based APIs.
 
 Please refer to the [Quarkus Google Cloud Services extension](https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/index.html)
-documentation for details regarding configuration of the PubSub client.
+documentation for details regarding configuration of the Pub/Sub client.
 
 ## Configuring Tenants to use Pub/Sub based Messaging
 


### PR DESCRIPTION
This PR is a prerequisite in order to use only Pub/Sub as messaging infrastructure. As part of this architecture we added a Pub/Sub based subscriber functionality.

Added new package for the new subscriber functionality.

Used Google's Subscriber to subscribe messages from Google Pub/Sub.

Moved Pub/Sub publisher functionality to publisher package.

Added unittests.

Update documentation.