### PR TITLE
[#3471] Add Pub/Sub based Command & Control Implementation

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -369,6 +369,11 @@ quarkus.vertx.max-event-loop-execute-time=${max.event-loop.execute-time:20000}
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-command-pubsub</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-device-amqp</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommand.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommand.java
@@ -328,6 +328,11 @@ public final class ProtonBasedCommand implements Command {
         }
     }
 
+    @Override
+    public Map<String, String> getDeliveryFailureNotificationProperties() {
+        return null;
+    }
+
     /**
      * Validates the type of the message body containing the payload data and returns an error string if it is
      * unsupported.

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandContext.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandContext.java
@@ -85,7 +85,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void accept() {
-        if (!setCompleted(ACCEPTED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_ACCEPTED)) {
             return;
         }
         Tags.HTTP_STATUS.set(getTracingSpan(), HttpURLConnection.HTTP_ACCEPTED);
@@ -94,7 +94,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void release() {
-        if (!setCompleted(RELEASED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_RELEASED)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "command could not be delivered or processed");
@@ -105,7 +105,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
     @Override
     public void release(final Throwable error) {
         Objects.requireNonNull(error);
-        if (!setCompleted(RELEASED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_RELEASED)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "command could not be delivered or processed", error);
@@ -116,7 +116,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
-        if (!setCompleted(MODIFIED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_MODIFIED)) {
             return;
         }
         final Span span = getTracingSpan();
@@ -134,7 +134,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void reject(final String error) {
-        if (!setCompleted(REJECTED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_REJECTED)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command: " + error);
@@ -147,7 +147,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void reject(final Throwable error) {
-        if (!setCompleted(REJECTED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_REJECTED)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command", error);

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandContext.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandContext.java
@@ -85,7 +85,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void accept() {
-        if (!setCompleted("accepted")) {
+        if (!setCompleted(ACCEPTED_COMMAND_CONTEXT)) {
             return;
         }
         Tags.HTTP_STATUS.set(getTracingSpan(), HttpURLConnection.HTTP_ACCEPTED);
@@ -94,7 +94,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void release() {
-        if (!setCompleted("released")) {
+        if (!setCompleted(RELEASED_COMMAND_CONTEXT)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "command could not be delivered or processed");
@@ -105,7 +105,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
     @Override
     public void release(final Throwable error) {
         Objects.requireNonNull(error);
-        if (!setCompleted("released")) {
+        if (!setCompleted(RELEASED_COMMAND_CONTEXT)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "command could not be delivered or processed", error);
@@ -116,7 +116,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
-        if (!setCompleted("modified")) {
+        if (!setCompleted(MODIFIED_COMMAND_CONTEXT)) {
             return;
         }
         final Span span = getTracingSpan();
@@ -134,7 +134,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void reject(final String error) {
-        if (!setCompleted("rejected")) {
+        if (!setCompleted(REJECTED_COMMAND_CONTEXT)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command: " + error);
@@ -147,7 +147,7 @@ public class ProtonBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void reject(final Throwable error) {
-        if (!setCompleted("rejected")) {
+        if (!setCompleted(REJECTED_COMMAND_CONTEXT)) {
             return;
         }
         TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command", error);

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedInternalCommandSender.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedInternalCommandSender.java
@@ -72,7 +72,7 @@ public class ProtonBasedInternalCommandSender extends SenderCachingServiceClient
         return getOrCreateSenderLink(getTargetAddress(adapterInstanceId))
                 .recover(thr -> Future.failedFuture(StatusCodeMapper.toServerError(thr)))
                 .compose(sender -> {
-                    final Span span = newChildSpan(commandContext.getTracingContext(), "delegate Command request");
+                    final Span span = newChildSpan(commandContext.getTracingContext(), CommandConstants.INTERNAL_COMMAND_SPAN_OPERATION_NAME);
                     final Command command = commandContext.getCommand();
                     final Message message = adoptOrCreateMessage(command);
                     TracingHelper.setDeviceTags(span, command.getTenant(), command.getDeviceId());

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommand.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommand.java
@@ -192,11 +192,7 @@ public final class KafkaBasedCommand implements Command {
                 responseRequired);
     }
 
-    /**
-     * Gets the set of properties to be set on the command response message if delivery of this command fails.
-     *
-     * @return The properties.
-     */
+    @Override
     public Map<String, String> getDeliveryFailureNotificationProperties() {
         return record.headers().stream()
                 .filter(header -> header.key()

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedCommandContext.java
@@ -36,7 +36,7 @@ import io.opentracing.tag.Tags;
  * A context for passing around parameters relevant for processing a {@code Command} used in a Kafka based
  * client.
  */
-public class KafkaBasedCommandContext extends AbstractCommandContext implements CommandContext {
+public class KafkaBasedCommandContext extends AbstractCommandContext<KafkaBasedCommand> implements CommandContext {
 
     private static final String PROPERTY_NAME_DELIVERY_FAILURE_RESPONSES_DISABLED = "HONO_DISABLE_KAFKA_COMMAND_DELIVERY_FAILURE_RESPONSES";
     private static final boolean DELIVERY_FAILURE_RESPONSES_DISABLED = Boolean
@@ -142,13 +142,9 @@ public class KafkaBasedCommandContext extends AbstractCommandContext implements 
     }
 
     private String getCorrelationId() {
-        if (getCommand() instanceof KafkaBasedCommand kafkaBasedCommand) {
-            // extract correlation id from headers; command could be invalid in which case
-            // command.getCorrelationId() throws an exception
-            return KafkaRecordHelper.getCorrelationId(kafkaBasedCommand.getRecord().headers()).orElse(null);
-        } else {
-            return null;
-        }
+        // extract correlation id from headers; command could be invalid in which case
+        // command.getCorrelationId() throws an exception
+        return KafkaRecordHelper.getCorrelationId(getCommand().getRecord().headers()).orElse(null);
     }
 
     private static String getProperty(final String name) {

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandSender.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandSender.java
@@ -27,6 +27,7 @@ import org.eclipse.hono.client.kafka.KafkaRecordHelper;
 import org.eclipse.hono.client.kafka.producer.AbstractKafkaBasedMessageSender;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
+import org.eclipse.hono.util.CommandConstants;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
@@ -73,7 +74,7 @@ public class KafkaBasedInternalCommandSender extends AbstractKafkaBasedMessageSe
 
         final String topicName = getInternalCommandTopic(adapterInstanceId);
         final Span currentSpan = startChildSpan(
-                "delegate Command request",
+                CommandConstants.INTERNAL_COMMAND_SPAN_OPERATION_NAME,
                 topicName,
                 command.getTenant(),
                 command.getDeviceId(),

--- a/clients/command-pubsub/pom.xml
+++ b/clients/command-pubsub/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.hono</groupId>
+    <artifactId>hono-clients-parent</artifactId>
+    <version>2.4.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>hono-client-command-pubsub</artifactId>
+
+  <name>Hono Client for Command &amp; Control (Pub/Sub)</name>
+  <description>An Pub/Sub based implementation of the client for Hono's south bound Command and Control API</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-command</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-pubsub-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-registry</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommand.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommand.java
@@ -1,0 +1,309 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import org.eclipse.hono.client.command.Command;
+import org.eclipse.hono.client.command.Commands;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.MessagingType;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Span;
+import io.opentracing.log.Fields;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * A command used in a Pub/Sub based client.
+ */
+public class PubSubBasedCommand implements Command {
+
+    /**
+     * If present, the command is invalid.
+     */
+    private final Optional<String> validationError;
+    private final PubsubMessage pubsubMessage;
+    private final String tenantId;
+    private final String deviceId;
+    private final String correlationId;
+    private final String subject;
+    private final String contentType;
+    private final String requestId;
+    private final boolean responseRequired;
+
+    private String gatewayId;
+
+    private PubSubBasedCommand(
+            final Optional<String> validationError,
+            final PubsubMessage pubsubMessage,
+            final String tenantId,
+            final String deviceId,
+            final String correlationId,
+            final String subject,
+            final String contentType,
+            final boolean responseRequired) {
+
+        this.validationError = validationError;
+        this.pubsubMessage = pubsubMessage;
+        this.tenantId = Objects.requireNonNull(tenantId);
+        this.deviceId = Objects.requireNonNull(deviceId);
+        this.correlationId = correlationId;
+        this.subject = subject;
+        this.contentType = contentType;
+        this.responseRequired = responseRequired;
+        this.requestId = Commands.encodeRequestIdParameters(correlationId, MessagingType.pubsub);
+    }
+
+    /**
+     * Creates a command from a Pub/Sub message, forwarded by the Command Router.
+     * The message is required to contain a <em>tenant_id</em> attribute and a <em>device_id</em> attribute. If any of
+     * these attributes are null or empty, an {@link IllegalArgumentException} is thrown.
+     *
+     * In addition, the attributes map is expected to contain
+     * <ul>
+     * <li>a <em>subject</em> entry</li>
+     * <li>a non-empty <em>correlation-id</em> entry if the <em>response-required</em> entry has the value
+     * {@code true}.</li>
+     * </ul>
+     * or otherwise the returned command's {@link #isValid()} method will return {@code false}.
+     * <p>
+     *
+     * @param pubsubMessage The Pub/Sub message containing the command.
+     * @return The command.
+     * @throws NullPointerException If pubsubMessage is {@code null}.
+     * @throws IllegalArgumentException If the pubsubMessage's attributes are empty or do not contain a tenant
+     *             identifier and a target device identifier.
+     */
+    public static PubSubBasedCommand fromRoutedCommandMessage(final PubsubMessage pubsubMessage) {
+        Objects.requireNonNull(pubsubMessage);
+
+        final String tenantId = PubSubMessageHelper.getTenantId(pubsubMessage.getAttributesMap())
+                .filter(id -> !id.isEmpty())
+                .orElseThrow(() -> new IllegalArgumentException("Tenant ID is not set"));
+        final PubSubBasedCommand command = getCommand(pubsubMessage, tenantId);
+
+        PubSubMessageHelper.getVia(pubsubMessage.getAttributesMap())
+                .filter(id -> !id.isEmpty())
+                .ifPresent(command::setGatewayId);
+
+        return command;
+    }
+
+    /**
+     * Creates a command from a Pub/Sub message.
+     * The message is required to contain an attributes map.
+     *
+     * @param pubsubMessage The Pub/Sub message containing the command.
+     * @param tenantId The tenant this Pub/Sub message belongs to.
+     * @return The command.
+     * @throws NullPointerException If pubsubMessage is {@code null}.
+     * @throws IllegalArgumentException If the attributesMap is empty or if the attributesMap does not contain a target
+     *             device identifier.
+     */
+    public static PubSubBasedCommand from(final PubsubMessage pubsubMessage, final String tenantId) {
+        Objects.requireNonNull(pubsubMessage);
+        return getCommand(pubsubMessage, tenantId);
+    }
+
+    private static PubSubBasedCommand getCommand(final PubsubMessage pubsubMessage, final String tenantId) {
+        final Map<String, String> attributes = pubsubMessage.getAttributesMap();
+        if (attributes.isEmpty()) {
+            throw new IllegalArgumentException("attributes not set");
+        }
+
+        final String deviceId = PubSubMessageHelper.getDeviceId(attributes)
+                .filter(id -> !id.isEmpty())
+                .orElseThrow(() -> new IllegalArgumentException("device ID is not set"));
+
+        final StringJoiner validationErrorJoiner = new StringJoiner(", ");
+        final boolean responseRequired = PubSubMessageHelper.isResponseRequired(attributes);
+        final String correlationId = PubSubMessageHelper.getCorrelationId(attributes)
+                .filter(id -> !id.isEmpty())
+                .orElseGet(() -> {
+                    if (responseRequired) {
+                        validationErrorJoiner.add("correlation-id is not set");
+                    }
+                    return null;
+                });
+        final String subject = PubSubMessageHelper.getSubject(attributes)
+                .orElseGet(() -> {
+                    validationErrorJoiner.add("subject not set");
+                    return null;
+                });
+        final String contentType = PubSubMessageHelper.getContentType(attributes).orElse(null);
+
+        return new PubSubBasedCommand(
+                validationErrorJoiner.length() > 0 ? Optional.of(validationErrorJoiner.toString()) : Optional.empty(),
+                pubsubMessage,
+                tenantId,
+                deviceId,
+                correlationId,
+                subject,
+                contentType,
+                responseRequired);
+    }
+
+    /**
+     * Returns the Pub/Sub message corresponding to this command.
+     *
+     * @return The Pub/Sub message.
+     */
+    public PubsubMessage getPubsubMessage() {
+        return pubsubMessage;
+    }
+
+    @Override
+    public boolean isOneWay() {
+        return !responseRequired;
+    }
+
+    @Override
+    public boolean isValid() {
+        return validationError.isEmpty();
+    }
+
+    @Override
+    public String getInvalidCommandReason() {
+        if (validationError.isEmpty()) {
+            throw new IllegalStateException("command is valid");
+        }
+        return validationError.get();
+    }
+
+    @Override
+    public String getTenant() {
+        return tenantId;
+    }
+
+    @Override
+    public String getGatewayOrDeviceId() {
+        return Optional.ofNullable(gatewayId).orElse(deviceId);
+    }
+
+    @Override
+    public boolean isTargetedAtGateway() {
+        return gatewayId != null;
+    }
+
+    @Override
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    @Override
+    public String getGatewayId() {
+        return gatewayId;
+    }
+
+    @Override
+    public void setGatewayId(final String gatewayId) {
+        this.gatewayId = gatewayId;
+    }
+
+    @Override
+    public String getName() {
+        requireValid();
+        return subject;
+    }
+
+    @Override
+    public String getRequestId() {
+        return requestId;
+    }
+
+    @Override
+    public Buffer getPayload() {
+        final byte[] bytePayload = PubSubMessageHelper.getPayload(pubsubMessage);
+        return Buffer.buffer(bytePayload);
+    }
+
+    @Override
+    public int getPayloadSize() {
+        final byte[] bytePayload = PubSubMessageHelper.getPayload(pubsubMessage);
+        return Optional.ofNullable(bytePayload).map(bytes -> bytes.length).orElse(0);
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public String getReplyToId() {
+        return null;
+    }
+
+    @Override
+    public String getCorrelationId() {
+        requireValid();
+        return correlationId;
+    }
+
+    @Override
+    public MessagingType getMessagingType() {
+        return MessagingType.pubsub;
+    }
+
+    @Override
+    public String toString() {
+        if (isValid()) {
+            if (isTargetedAtGateway()) {
+                return String.format("Command [name: %s, tenant-id: %s, gateway-id: %s, device-id: %s, request-id: %s]",
+                        subject, tenantId, gatewayId, deviceId, requestId);
+            } else {
+                return String.format("Command [name: %s, tenant-id: %s, device-id: %s, request-id: %s]",
+                        subject, tenantId, deviceId, requestId);
+            }
+        } else {
+            return String.format("Invalid Command [tenant-id: %s, device-id: %s. error: %s]", tenantId,
+                    deviceId, validationError.get());
+        }
+    }
+
+    @Override
+    public void logToSpan(final Span span) {
+        Objects.requireNonNull(span);
+        if (isValid()) {
+            TracingHelper.TAG_CORRELATION_ID.set(span, correlationId);
+            final Map<String, Object> items = new HashMap<>(3);
+            items.put(Fields.EVENT, "received command message via Pub/Sub");
+            items.put("subject", subject);
+            items.put("content-type", contentType);
+            span.log(items);
+        } else {
+            TracingHelper.logError(span, "received invalid command message [" + this + "]");
+        }
+    }
+
+    /**
+     * Gets the set of properties to be set on the command response message if delivery of this command fails.
+     *
+     * @return The properties.
+     */
+    public Map<String, String> getDeliveryFailureNotificationProperties() {
+        return PubSubMessageHelper.getDeliveryFailureNotificationMetadata(pubsubMessage.getAttributesMap());
+    }
+
+    private void requireValid() {
+        if (!isValid()) {
+            throw new IllegalStateException("command is invalid");
+        }
+    }
+}

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommand.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommand.java
@@ -33,7 +33,7 @@ import io.vertx.core.buffer.Buffer;
 /**
  * A command used in a Pub/Sub based client.
  */
-public class PubSubBasedCommand implements Command {
+public final class PubSubBasedCommand implements Command {
 
     /**
      * If present, the command is invalid.
@@ -292,11 +292,7 @@ public class PubSubBasedCommand implements Command {
         }
     }
 
-    /**
-     * Gets the set of properties to be set on the command response message if delivery of this command fails.
-     *
-     * @return The properties.
-     */
+    @Override
     public Map<String, String> getDeliveryFailureNotificationProperties() {
         return PubSubMessageHelper.getDeliveryFailureNotificationMetadata(pubsubMessage.getAttributesMap());
     }

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContext.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContext.java
@@ -1,17 +1,16 @@
-/*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * https://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- *******************************************************************************/
-
-package org.eclipse.hono.client.command.kafka;
+ */
+package org.eclipse.hono.client.command.pubsub;
 
 import java.net.HttpURLConnection;
 import java.util.Collections;
@@ -25,7 +24,7 @@ import org.eclipse.hono.client.command.CommandContext;
 import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.command.CommandToBeReprocessedException;
-import org.eclipse.hono.client.kafka.KafkaRecordHelper;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
 import org.eclipse.hono.client.util.StatusCodeMapper;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;
@@ -42,23 +41,13 @@ import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
 /**
- * A context for passing around parameters relevant for processing a {@code Command} used in a Kafka based
- * client.
+ * A context for passing around parameters relevant for processing a {@code Command} used in a Pub/Sub based client.
  */
-public class KafkaBasedCommandContext extends MapBasedExecutionContext implements CommandContext {
+public class PubSubBasedCommandContext extends MapBasedExecutionContext implements CommandContext {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaBasedCommandContext.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PubSubBasedCommandContext.class);
 
-    private static final String PROPERTY_NAME_DELIVERY_FAILURE_RESPONSES_DISABLED = "HONO_DISABLE_KAFKA_COMMAND_DELIVERY_FAILURE_RESPONSES";
-    private static final boolean DELIVERY_FAILURE_RESPONSES_DISABLED = Boolean
-            .parseBoolean(getProperty(PROPERTY_NAME_DELIVERY_FAILURE_RESPONSES_DISABLED));
-    static {
-        if (DELIVERY_FAILURE_RESPONSES_DISABLED) {
-            LOG.info("sending of command delivery failure response messages is disabled");
-        }
-    }
-
-    private final KafkaBasedCommand command;
+    private final PubSubBasedCommand command;
     private final CommandResponseSender commandResponseSender;
     private String completedOutcome;
 
@@ -68,10 +57,10 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
      * @param command The command to be processed.
      * @param commandResponseSender The sender used to send a command response.
      * @param span The OpenTracing span to use for tracking the processing of the command.
-     * @throws NullPointerException if any of the parameters are {@code null}.
+     * @throws NullPointerException If any of the parameters are {@code null}.
      */
-    public KafkaBasedCommandContext(
-            final KafkaBasedCommand command,
+    public PubSubBasedCommandContext(
+            final PubSubBasedCommand command,
             final CommandResponseSender commandResponseSender,
             final Span span) {
         super(span);
@@ -80,34 +69,34 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
     }
 
     @Override
-    public final boolean isCompleted() {
+    public boolean isCompleted() {
         return completedOutcome != null;
     }
 
     @Override
-    public final void logCommandToSpan(final Span span) {
+    public void logCommandToSpan(final Span span) {
         command.logToSpan(span);
     }
 
     @Override
-    public final KafkaBasedCommand getCommand() {
+    public PubSubBasedCommand getCommand() {
         return command;
     }
 
     @Override
-    public final void accept() {
+    public void accept() {
         if (!setCompleted(ACCEPTED_COMMAND_CONTEXT)) {
             return;
         }
         final Span span = getTracingSpan();
-        LOG.trace("accepted command message [{}]", getCommand());
+        LOG.debug("accepted command message [{}]", getCommand());
         Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_ACCEPTED);
         span.log("command for device handled with outcome 'accepted'");
         span.finish();
     }
 
     @Override
-    public final void release(final Throwable error) {
+    public void release(final Throwable error) {
         Objects.requireNonNull(error);
         if (!setCompleted(RELEASED_COMMAND_CONTEXT)) {
             return;
@@ -117,10 +106,10 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
         final ServiceInvocationException mappedError = StatusCodeMapper.toServerError(error);
         final int status = mappedError.getErrorCode();
         Tags.HTTP_STATUS.set(span, status);
-        if (!DELIVERY_FAILURE_RESPONSES_DISABLED && isRequestResponseCommand()
-                && !(error instanceof CommandAlreadyProcessedException)
+        if (isRequestResponseCommand() && !(error instanceof CommandAlreadyProcessedException)
                 && !(error instanceof CommandToBeReprocessedException)) {
-            final String errorMessage = Optional.ofNullable(ServiceInvocationException.getErrorMessageForExternalClient(mappedError))
+            final String errorMessage = Optional
+                    .ofNullable(ServiceInvocationException.getErrorMessageForExternalClient(mappedError))
                     .orElse("Temporarily unavailable");
             sendDeliveryFailureCommandResponseMessage(status, errorMessage, span, error)
                     .onComplete(v -> span.finish());
@@ -130,21 +119,22 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
     }
 
     @Override
-    public final void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
+    public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
         if (!setCompleted(MODIFIED_COMMAND_CONTEXT)) {
             return;
         }
+
+        final String deliveryFailedReason = deliveryFailed ? "; delivery failed" : "";
+        final String undeliverableHereReason = undeliverableHere ? "; undeliverable here" : "";
+        final int status = undeliverableHere ? HttpURLConnection.HTTP_NOT_FOUND : HttpURLConnection.HTTP_UNAVAILABLE;
+
         final Span span = getTracingSpan();
-        TracingHelper.logError(span, "command for device handled with outcome 'modified'"
-                + (deliveryFailed ? "; delivery failed" : "")
-                + (undeliverableHere ? "; undeliverable here" : ""));
-        final int status = undeliverableHere ? HttpURLConnection.HTTP_NOT_FOUND
-                : HttpURLConnection.HTTP_UNAVAILABLE;
+        TracingHelper.logError(span, String.format("command for device handled with outcome 'modified' %s %s",
+                deliveryFailedReason, undeliverableHereReason));
         Tags.HTTP_STATUS.set(span, status);
-        if (!DELIVERY_FAILURE_RESPONSES_DISABLED && isRequestResponseCommand()) {
-            final String error = "command not processed"
-                    + (deliveryFailed ? "; delivery failed" : "")
-                    + (undeliverableHere ? "; undeliverable here" : "");
+        if (isRequestResponseCommand()) {
+            final String error = String.format("command not processed %s %s", deliveryFailedReason,
+                    undeliverableHereReason);
             sendDeliveryFailureCommandResponseMessage(status, error, span, null)
                     .onComplete(v -> span.finish());
         } else {
@@ -153,88 +143,23 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
     }
 
     @Override
-    public final void reject(final String error) {
-        TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command: " + error);
-        reject(HttpURLConnection.HTTP_BAD_REQUEST, error);
-    }
-
-    @Override
-    public final void reject(final Throwable error) {
-        final int status = error instanceof ClientErrorException
-                ? ((ClientErrorException) error).getErrorCode()
-                : HttpURLConnection.HTTP_BAD_REQUEST;
-        TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command", error);
-        reject(status, error.getMessage());
-    }
-
-    private void reject(final int status, final String cause) {
+    public void reject(final Throwable error) {
         if (!setCompleted(REJECTED_COMMAND_CONTEXT)) {
             return;
         }
+        final int status = error instanceof ClientErrorException clientErrorException
+                ? clientErrorException.getErrorCode()
+                : HttpURLConnection.HTTP_BAD_REQUEST;
+        TracingHelper.logError(getTracingSpan(), "client error trying to deliver or process command", error);
         final Span span = getTracingSpan();
         Tags.HTTP_STATUS.set(span, status);
-        if (!DELIVERY_FAILURE_RESPONSES_DISABLED && isRequestResponseCommand()) {
-            final String nonNullCause = Optional.ofNullable(cause).orElse("Command message rejected");
+        if (isRequestResponseCommand()) {
+            final String nonNullCause = Optional.ofNullable(error.getMessage()).orElse("Command message rejected");
             sendDeliveryFailureCommandResponseMessage(status, nonNullCause, span, null)
                     .onComplete(v -> span.finish());
         } else {
             span.finish();
         }
-    }
-
-    private boolean isRequestResponseCommand() {
-        return !command.isOneWay();
-    }
-
-    private Future<Void> sendDeliveryFailureCommandResponseMessage(
-            final int status,
-            final String error,
-            final Span span,
-            final Throwable cause) {
-
-        final JsonObject payloadJson = new JsonObject();
-        payloadJson.put("error", error != null ? error : "");
-        final String correlationId = getCorrelationId();
-        if (correlationId == null) {
-            TracingHelper.logError(span, "can't send command response message - no correlation id set");
-            return Future.failedFuture("missing correlation id");
-        }
-        final CommandResponse commandResponse = new CommandResponse(
-                command.getTenant(),
-                command.getDeviceId(),
-                payloadJson.toBuffer(),
-                CommandConstants.CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION,
-                status,
-                correlationId,
-                "",
-                MessagingType.kafka);
-        commandResponse.setAdditionalProperties(Collections.unmodifiableMap(command.getDeliveryFailureNotificationProperties()));
-
-        return commandResponseSender.sendCommandResponse(
-                // try to retrieve tenant configuration from context
-                Optional.ofNullable(get(KEY_TENANT_CONFIG))
-                    .filter(TenantObject.class::isInstance)
-                    .map(TenantObject.class::cast)
-                    // and fall back to default configuration
-                    .orElseGet(() -> TenantObject.from(command.getTenant())),
-                new RegistrationAssertion(command.getDeviceId()),
-                commandResponse,
-                span.context())
-            .onFailure(thr -> {
-                LOG.debug("failed to publish command response [{}]", commandResponse, thr);
-                TracingHelper.logError(span, "failed to publish command response message", thr);
-            })
-            .onSuccess(v -> {
-                LOG.debug("published error command response [{}, cause: {}]", commandResponse,
-                        cause != null ? cause.getMessage() : error);
-                span.log("published error command response");
-            });
-    }
-
-    private String getCorrelationId() {
-        // extract correlation id from headers; command could be invalid in which case
-        // command.getCorrelationId() throws an exception
-        return KafkaRecordHelper.getCorrelationId(command.getRecord().headers()).orElse(null);
     }
 
     private boolean setCompleted(final String outcome) {
@@ -247,7 +172,54 @@ public class KafkaBasedCommandContext extends MapBasedExecutionContext implement
         return true;
     }
 
-    private static String getProperty(final String name) {
-        return System.getProperty(name, System.getenv(name));
+    private boolean isRequestResponseCommand() {
+        return !command.isOneWay();
+    }
+
+    private Future<Void> sendDeliveryFailureCommandResponseMessage(
+            final int status,
+            final String error,
+            final Span span,
+            final Throwable cause) {
+        final JsonObject payloadJson = new JsonObject();
+        payloadJson.put("error", error != null ? error : "");
+        final String correlationId = getCorrelationId();
+        if (correlationId == null) {
+            TracingHelper.logError(span, "can't send command response message - no correlation id set");
+            return Future.failedFuture("missing correlation id");
+        }
+
+        final CommandResponse commandResponse = new CommandResponse(
+                command.getTenant(),
+                command.getDeviceId(),
+                payloadJson.toBuffer(),
+                CommandConstants.CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION,
+                status,
+                correlationId,
+                "",
+                MessagingType.pubsub);
+        commandResponse.setAdditionalProperties(Collections.unmodifiableMap(command.getDeliveryFailureNotificationProperties()));
+
+        return commandResponseSender.sendCommandResponse(
+                Optional.ofNullable(get(KEY_TENANT_CONFIG))
+                        .filter(TenantObject.class::isInstance)
+                        .map(TenantObject.class::cast)
+                        .orElseGet(() -> TenantObject.from(command.getTenant())),
+                new RegistrationAssertion(command.getDeviceId()),
+                commandResponse,
+                span.context())
+                .onFailure(thr -> {
+                    LOG.debug("failed to publish command response [{}]", commandResponse, thr);
+                    TracingHelper.logError(span, "failed to publish command response message", thr);
+                })
+                .onSuccess(v -> {
+                    LOG.debug("published error command response [{}, cause: {}]", commandResponse,
+                            cause != null ? cause.getMessage() : error);
+                    span.log("published error command response");
+                });
+    }
+
+    private String getCorrelationId() {
+        return PubSubMessageHelper.getCorrelationId(command.getPubsubMessage().getAttributesMap()).orElse(null);
     }
 }

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContext.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContext.java
@@ -34,7 +34,7 @@ import io.opentracing.tag.Tags;
 /**
  * A context for passing around parameters relevant for processing a {@code Command} used in a Pub/Sub based client.
  */
-public class PubSubBasedCommandContext extends AbstractCommandContext implements CommandContext {
+public class PubSubBasedCommandContext extends AbstractCommandContext<PubSubBasedCommand> implements CommandContext {
 
     /**
      * Creates a new command context.
@@ -124,12 +124,8 @@ public class PubSubBasedCommandContext extends AbstractCommandContext implements
     }
 
     private String getCorrelationId() {
-        if (getCommand() instanceof PubSubBasedCommand pubSubBasedCommand) {
-            return PubSubMessageHelper
-                    .getCorrelationId(pubSubBasedCommand.getPubsubMessage().getAttributesMap())
-                    .orElse(null);
-        } else {
-            return null;
-        }
+        return PubSubMessageHelper
+                .getCorrelationId(getCommand().getPubsubMessage().getAttributesMap())
+                .orElse(null);
     }
 }

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContext.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContext.java
@@ -13,43 +13,28 @@
 package org.eclipse.hono.client.command.pubsub;
 
 import java.net.HttpURLConnection;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.hono.client.ClientErrorException;
 import org.eclipse.hono.client.ServiceInvocationException;
+import org.eclipse.hono.client.command.AbstractCommandContext;
 import org.eclipse.hono.client.command.CommandAlreadyProcessedException;
 import org.eclipse.hono.client.command.CommandContext;
-import org.eclipse.hono.client.command.CommandResponse;
 import org.eclipse.hono.client.command.CommandResponseSender;
 import org.eclipse.hono.client.command.CommandToBeReprocessedException;
 import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
 import org.eclipse.hono.client.util.StatusCodeMapper;
 import org.eclipse.hono.tracing.TracingHelper;
-import org.eclipse.hono.util.CommandConstants;
-import org.eclipse.hono.util.MapBasedExecutionContext;
 import org.eclipse.hono.util.MessagingType;
-import org.eclipse.hono.util.RegistrationAssertion;
-import org.eclipse.hono.util.TenantObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.tag.Tags;
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 
 /**
  * A context for passing around parameters relevant for processing a {@code Command} used in a Pub/Sub based client.
  */
-public class PubSubBasedCommandContext extends MapBasedExecutionContext implements CommandContext {
-
-    private static final Logger LOG = LoggerFactory.getLogger(PubSubBasedCommandContext.class);
-
-    private final PubSubBasedCommand command;
-    private final CommandResponseSender commandResponseSender;
-    private String completedOutcome;
+public class PubSubBasedCommandContext extends AbstractCommandContext implements CommandContext {
 
     /**
      * Creates a new command context.
@@ -63,42 +48,13 @@ public class PubSubBasedCommandContext extends MapBasedExecutionContext implemen
             final PubSubBasedCommand command,
             final CommandResponseSender commandResponseSender,
             final Span span) {
-        super(span);
-        this.command = Objects.requireNonNull(command);
-        this.commandResponseSender = Objects.requireNonNull(commandResponseSender);
-    }
-
-    @Override
-    public boolean isCompleted() {
-        return completedOutcome != null;
-    }
-
-    @Override
-    public void logCommandToSpan(final Span span) {
-        command.logToSpan(span);
-    }
-
-    @Override
-    public PubSubBasedCommand getCommand() {
-        return command;
-    }
-
-    @Override
-    public void accept() {
-        if (!setCompleted(ACCEPTED_COMMAND_CONTEXT)) {
-            return;
-        }
-        final Span span = getTracingSpan();
-        LOG.debug("accepted command message [{}]", getCommand());
-        Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_ACCEPTED);
-        span.log("command for device handled with outcome 'accepted'");
-        span.finish();
+        super(span, command, commandResponseSender);
     }
 
     @Override
     public void release(final Throwable error) {
         Objects.requireNonNull(error);
-        if (!setCompleted(RELEASED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_RELEASED)) {
             return;
         }
         final Span span = getTracingSpan();
@@ -111,8 +67,10 @@ public class PubSubBasedCommandContext extends MapBasedExecutionContext implemen
             final String errorMessage = Optional
                     .ofNullable(ServiceInvocationException.getErrorMessageForExternalClient(mappedError))
                     .orElse("Temporarily unavailable");
-            sendDeliveryFailureCommandResponseMessage(status, errorMessage, span, error)
-                    .onComplete(v -> span.finish());
+            final String correlationId = getCorrelationId();
+            sendDeliveryFailureCommandResponseMessage(status, errorMessage, span, error, correlationId,
+                    MessagingType.pubsub)
+                            .onComplete(v -> span.finish());
         } else {
             span.finish();
         }
@@ -120,7 +78,7 @@ public class PubSubBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void modify(final boolean deliveryFailed, final boolean undeliverableHere) {
-        if (!setCompleted(MODIFIED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_MODIFIED)) {
             return;
         }
 
@@ -135,7 +93,8 @@ public class PubSubBasedCommandContext extends MapBasedExecutionContext implemen
         if (isRequestResponseCommand()) {
             final String error = String.format("command not processed %s %s", deliveryFailedReason,
                     undeliverableHereReason);
-            sendDeliveryFailureCommandResponseMessage(status, error, span, null)
+            final String correlationId = getCorrelationId();
+            sendDeliveryFailureCommandResponseMessage(status, error, span, null, correlationId, MessagingType.pubsub)
                     .onComplete(v -> span.finish());
         } else {
             span.finish();
@@ -144,7 +103,7 @@ public class PubSubBasedCommandContext extends MapBasedExecutionContext implemen
 
     @Override
     public void reject(final Throwable error) {
-        if (!setCompleted(REJECTED_COMMAND_CONTEXT)) {
+        if (!setCompleted(OUTCOME_REJECTED)) {
             return;
         }
         final int status = error instanceof ClientErrorException clientErrorException
@@ -155,71 +114,22 @@ public class PubSubBasedCommandContext extends MapBasedExecutionContext implemen
         Tags.HTTP_STATUS.set(span, status);
         if (isRequestResponseCommand()) {
             final String nonNullCause = Optional.ofNullable(error.getMessage()).orElse("Command message rejected");
-            sendDeliveryFailureCommandResponseMessage(status, nonNullCause, span, null)
-                    .onComplete(v -> span.finish());
+            final String correlationId = getCorrelationId();
+            sendDeliveryFailureCommandResponseMessage(status, nonNullCause, span, null, correlationId,
+                    MessagingType.pubsub)
+                            .onComplete(v -> span.finish());
         } else {
             span.finish();
         }
     }
 
-    private boolean setCompleted(final String outcome) {
-        if (completedOutcome != null) {
-            LOG.warn("can't apply '{}' outcome, context already completed with '{}' outcome [{}]",
-                    outcome, completedOutcome, getCommand());
-            return false;
-        }
-        completedOutcome = outcome;
-        return true;
-    }
-
-    private boolean isRequestResponseCommand() {
-        return !command.isOneWay();
-    }
-
-    private Future<Void> sendDeliveryFailureCommandResponseMessage(
-            final int status,
-            final String error,
-            final Span span,
-            final Throwable cause) {
-        final JsonObject payloadJson = new JsonObject();
-        payloadJson.put("error", error != null ? error : "");
-        final String correlationId = getCorrelationId();
-        if (correlationId == null) {
-            TracingHelper.logError(span, "can't send command response message - no correlation id set");
-            return Future.failedFuture("missing correlation id");
-        }
-
-        final CommandResponse commandResponse = new CommandResponse(
-                command.getTenant(),
-                command.getDeviceId(),
-                payloadJson.toBuffer(),
-                CommandConstants.CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION,
-                status,
-                correlationId,
-                "",
-                MessagingType.pubsub);
-        commandResponse.setAdditionalProperties(Collections.unmodifiableMap(command.getDeliveryFailureNotificationProperties()));
-
-        return commandResponseSender.sendCommandResponse(
-                Optional.ofNullable(get(KEY_TENANT_CONFIG))
-                        .filter(TenantObject.class::isInstance)
-                        .map(TenantObject.class::cast)
-                        .orElseGet(() -> TenantObject.from(command.getTenant())),
-                new RegistrationAssertion(command.getDeviceId()),
-                commandResponse,
-                span.context())
-                .onFailure(thr -> {
-                    LOG.debug("failed to publish command response [{}]", commandResponse, thr);
-                    TracingHelper.logError(span, "failed to publish command response message", thr);
-                })
-                .onSuccess(v -> {
-                    LOG.debug("published error command response [{}, cause: {}]", commandResponse,
-                            cause != null ? cause.getMessage() : error);
-                    span.log("published error command response");
-                });
-    }
-
     private String getCorrelationId() {
-        return PubSubMessageHelper.getCorrelationId(command.getPubsubMessage().getAttributesMap()).orElse(null);
+        if (getCommand() instanceof PubSubBasedCommand pubSubBasedCommand) {
+            return PubSubMessageHelper
+                    .getCorrelationId(pubSubBasedCommand.getPubsubMessage().getAttributesMap())
+                    .orElse(null);
+        } else {
+            return null;
+        }
     }
 }

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandResponseSender.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandResponseSender.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.hono.client.command.CommandResponse;
+import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.pubsub.AbstractPubSubBasedMessageSender;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
+import org.eclipse.hono.client.util.DownstreamMessageProperties;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * A Pub/Sub based client for sending command response messages downstream via Google Pub/Sub.
+ */
+public class PubSubBasedCommandResponseSender extends AbstractPubSubBasedMessageSender implements
+        CommandResponseSender {
+
+    /**
+     * Creates a new Pub/Sub based command response sender.
+     *
+     * @param vertx The vert.x instance to use.
+     * @param publisherFactory The factory to use for creating Pub/Sub publishers.
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public PubSubBasedCommandResponseSender(final Vertx vertx, final PubSubPublisherFactory publisherFactory,
+            final String projectId, final Tracer tracer) {
+        super(publisherFactory, CommandConstants.COMMAND_RESPONSE_ENDPOINT, projectId, tracer);
+        Objects.requireNonNull(vertx);
+
+        NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
+                notification -> {
+                    if (LifecycleChange.DELETE.equals(notification.getChange())) {
+                        publisherFactory
+                                .getPublisher(CommandConstants.COMMAND_RESPONSE_ENDPOINT, notification.getTenantId())
+                                .ifPresent(publisher -> publisherFactory.closePublisher(
+                                        CommandConstants.COMMAND_RESPONSE_ENDPOINT,
+                                        notification.getTenantId()));
+                    }
+                });
+    }
+
+    @Override
+    public Future<Void> sendCommandResponse(
+            final TenantObject tenant,
+            final RegistrationAssertion device,
+            final CommandResponse response,
+            final SpanContext context) {
+
+        Objects.requireNonNull(tenant);
+        Objects.requireNonNull(device);
+        Objects.requireNonNull(response);
+
+        if (log.isTraceEnabled()) {
+            log.trace("publish command response [{}]", response);
+        }
+        final Span span = startSpan(
+                "forward Command response",
+                response.getTenantId(),
+                response.getDeviceId(),
+                References.CHILD_OF,
+                context);
+        if (response.getMessagingType() != getMessagingType()) {
+            span.log(String.format("using messaging type %s instead of type %s used for the original command",
+                    getMessagingType(), response.getMessagingType()));
+        }
+        final Map<String, Object> properties = getMessageProperties(response, tenant, device);
+        final String topic = PubSubMessageHelper.getTopicName(CommandConstants.COMMAND_RESPONSE_ENDPOINT,
+                response.getTenantId());
+        return sendAndWaitForOutcome(
+                topic,
+                response.getTenantId(),
+                response.getDeviceId(),
+                response.getPayload(),
+                properties,
+                span)
+                .onComplete(ar -> span.finish());
+    }
+
+    private Map<String, Object> getMessageProperties(final CommandResponse response, final TenantObject tenant,
+            final RegistrationAssertion device) {
+        final var messageProperties = new DownstreamMessageProperties(
+                CommandConstants.NORTHBOUND_COMMAND_RESPONSE_ENDPOINT,
+                tenant.getDefaults().getMap(),
+                device.getDefaults(),
+                response.getAdditionalProperties(),
+                tenant.getResourceLimits()).asMap();
+        messageProperties.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, response.getCorrelationId());
+        messageProperties.put(MessageHelper.APP_PROPERTY_STATUS, response.getStatus());
+        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, response.getTenantId());
+        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, response.getTenantId());
+        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, response.getDeviceId());
+        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
+
+        if (response.getContentType() != null) {
+            messageProperties.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, response.getContentType());
+        } else if (response.getPayload() != null) {
+            messageProperties.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, MessageHelper.CONTENT_TYPE_OCTET_STREAM);
+        }
+        return messageProperties;
+    }
+}

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandResponseSender.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandResponseSender.java
@@ -115,10 +115,8 @@ public class PubSubBasedCommandResponseSender extends AbstractPubSubBasedMessage
                 tenant.getResourceLimits()).asMap();
         messageProperties.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, response.getCorrelationId());
         messageProperties.put(MessageHelper.APP_PROPERTY_STATUS, response.getStatus());
-        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, response.getTenantId());
-        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, response.getTenantId());
-        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, response.getDeviceId());
-        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
+        messageProperties.put(MessageHelper.APP_PROPERTY_TENANT_ID, response.getTenantId());
+        messageProperties.put(MessageHelper.APP_PROPERTY_DEVICE_ID, response.getDeviceId());
 
         if (response.getContentType() != null) {
             messageProperties.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, response.getContentType());

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumer.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumer.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import java.net.HttpURLConnection;
+import java.util.Objects;
+
+import org.eclipse.hono.client.NoConsumerException;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.CommandHandlerWrapper;
+import org.eclipse.hono.client.command.CommandHandlers;
+import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.command.InternalCommandConsumer;
+import org.eclipse.hono.client.pubsub.PubSubBasedAdminClientManager;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.client.pubsub.subscriber.PubSubSubscriberFactory;
+import org.eclipse.hono.client.pubsub.tracing.PubSubTracingHelper;
+import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.LifecycleStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+
+/**
+ * A Pub/Sub based consumer to receive commands forwarded by the Command Router on the internal command topic.
+ */
+public class PubSubBasedInternalCommandConsumer implements InternalCommandConsumer {
+
+    private static final Logger log = LoggerFactory.getLogger(PubSubBasedInternalCommandConsumer.class);
+
+    private final CommandResponseSender commandResponseSender;
+    private final String adapterInstanceId;
+    private final CommandHandlers commandHandlers;
+    private final TenantClient tenantClient;
+    private final Tracer tracer;
+    private final PubSubSubscriberFactory subscriberFactory;
+    private final LifecycleStatus lifecycleStatus = new LifecycleStatus();
+    private final PubSubBasedAdminClientManager adminClientManager;
+    private MessageReceiver receiver;
+
+    /**
+     * Creates a Pub/Sub based internal command consumer.
+     *
+     * @param commandResponseSender The sender used to send command responses.
+     * @param vertx The Vert.x instance to use.
+     * @param adapterInstanceId The adapter instance id.
+     * @param commandHandlers The command handlers to choose from for handling a received command.
+     * @param tenantClient The client to use for retrieving tenant configuration data.
+     * @param tracer The OpenTracing tracer.
+     * @param subscriberFactory The subscriber factory for creating Pub/Sub subscribers for receiving messages.
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param credentialsProvider The provider for credentials to use for authenticating to the Pub/Sub service.
+     * @throws NullPointerException If any of these parameters are {@code null}.
+     */
+    public PubSubBasedInternalCommandConsumer(
+            final CommandResponseSender commandResponseSender,
+            final Vertx vertx,
+            final String adapterInstanceId,
+            final CommandHandlers commandHandlers,
+            final TenantClient tenantClient,
+            final Tracer tracer,
+            final PubSubSubscriberFactory subscriberFactory,
+            final String projectId,
+            final CredentialsProvider credentialsProvider) {
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(projectId);
+        Objects.requireNonNull(credentialsProvider);
+        this.commandResponseSender = Objects.requireNonNull(commandResponseSender);
+        this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
+        this.commandHandlers = Objects.requireNonNull(commandHandlers);
+        this.tenantClient = Objects.requireNonNull(tenantClient);
+        this.tracer = Objects.requireNonNull(tracer);
+        this.subscriberFactory = Objects.requireNonNull(subscriberFactory);
+        this.adminClientManager = new PubSubBasedAdminClientManager(projectId, credentialsProvider, vertx);
+        createReceiver();
+        adminClientManager
+                .getOrCreateTopicAndSubscription(CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId)
+                .onFailure(thr -> log.error("Could not create subscription for endpoint {} and {}",
+                        CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId, thr))
+                .onSuccess(s -> subscriberFactory.getOrCreateSubscriber(s, receiver));
+    }
+
+    /**
+     * Creates a Pub/Sub based internal command consumer. To be used for Unittests.
+     *
+     * @param commandResponseSender The sender used to send command responses.
+     * @param adapterInstanceId The adapter instance id.
+     * @param commandHandlers The command handlers to choose from for handling a received command.
+     * @param tenantClient The client to use for retrieving tenant configuration data.
+     * @param tracer The OpenTracing tracer.
+     * @param subscriberFactory The subscriber factory for creating Pub/Sub subscribers for receiving messages.
+     * @param adminClientManager The Pub/Sub based admin client manager to manage topics and subscriptions.
+     * @param receiver The message receiver used to process the received message.
+     * @throws NullPointerException If any of these parameters are {@code null}.
+     */
+    public PubSubBasedInternalCommandConsumer(
+            final CommandResponseSender commandResponseSender,
+            final String adapterInstanceId,
+            final CommandHandlers commandHandlers,
+            final TenantClient tenantClient,
+            final Tracer tracer,
+            final PubSubSubscriberFactory subscriberFactory,
+            final PubSubBasedAdminClientManager adminClientManager,
+            final MessageReceiver receiver) {
+
+        this.commandResponseSender = Objects.requireNonNull(commandResponseSender);
+        this.adapterInstanceId = Objects.requireNonNull(adapterInstanceId);
+        this.commandHandlers = Objects.requireNonNull(commandHandlers);
+        this.tenantClient = Objects.requireNonNull(tenantClient);
+        this.tracer = Objects.requireNonNull(tracer);
+        this.subscriberFactory = Objects.requireNonNull(subscriberFactory);
+        this.adminClientManager = Objects.requireNonNull(adminClientManager);
+        this.receiver = Objects.requireNonNull(receiver);
+        adminClientManager
+                .getOrCreateTopicAndSubscription(CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId)
+                .onFailure(thr -> log.error("Could not create subscription for endpoint {} and {}",
+                        CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId, thr))
+                .onSuccess(s -> subscriberFactory.getOrCreateSubscriber(s, receiver));
+    }
+
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        log.trace("registering readiness check using Pub/Sub based internal command consumer [adapter instance id: {}]",
+                adapterInstanceId);
+        readinessHandler.register("internal-command-consumer[%s]-readiness".formatted(adapterInstanceId),
+                status -> {
+                    if (lifecycleStatus.isStarted()) {
+                        status.tryComplete(Status.OK());
+                    } else {
+                        final JsonObject data = new JsonObject();
+                        if (lifecycleStatus.isStarting()) {
+                            if (subscriberFactory
+                                    .getSubscriber(CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId)
+                                    .isEmpty()) {
+                                log.debug("readiness check failed, subscriber not created yet");
+                                data.put("status", "subscriber not created yet");
+                            } else {
+                                log.debug("readiness check failed");
+                            }
+                        }
+                        status.tryComplete(Status.KO(data));
+                    }
+                });
+    }
+
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        // no liveness checks to be added
+    }
+
+    @Override
+    public Future<Void> start() {
+        if (lifecycleStatus.isStarting()) {
+            return Future.succeededFuture();
+        } else if (!lifecycleStatus.setStarting()) {
+            return Future.failedFuture(new IllegalStateException("subscriber is already started/stopping"));
+        }
+
+        final String subscriptionId = PubSubMessageHelper.getTopicName(
+                CommandConstants.INTERNAL_COMMAND_ENDPOINT,
+                adapterInstanceId);
+        return subscriberFactory
+                .getOrCreateSubscriber(subscriptionId, receiver)
+                .subscribe(true)
+                .onSuccess(s -> lifecycleStatus.setStarted())
+                .onFailure(
+                        e -> log.warn("Error starting Internal Command Consumer for adapter {}", adapterInstanceId, e));
+    }
+
+    private void createReceiver() {
+        receiver = (PubsubMessage message, AckReplyConsumer consumer) -> {
+            handleCommandMessage(message);
+        };
+    }
+
+    Future<Void> handleCommandMessage(final PubsubMessage message) {
+        final PubSubBasedCommand command;
+        try {
+            command = PubSubBasedCommand.fromRoutedCommandMessage(message);
+        } catch (IllegalArgumentException e) {
+            log.warn("Command record is invalid [tenant-id: {}, device-id: {}]",
+                    PubSubMessageHelper.getTenantId(message.getAttributesMap()).orElse(null),
+                    PubSubMessageHelper.getDeviceId(message.getAttributesMap()).orElse(null), e);
+            return Future.failedFuture("invalid command message");
+        }
+
+        final CommandHandlerWrapper commandHandler = commandHandlers.getCommandHandler(command.getTenant(),
+                command.getGatewayOrDeviceId());
+        if (commandHandler != null && commandHandler.getGatewayId() != null) {
+            command.setGatewayId(commandHandler.getGatewayId());
+        }
+        final SpanContext spanContext = PubSubTracingHelper.extractSpanContext(tracer, message);
+        final SpanContext followsFromSpanContext = commandHandler != null
+                ? commandHandler.getConsumerCreationSpanContext()
+                : null;
+        final Span currentSpan = CommandContext.createSpan(tracer, command, spanContext, followsFromSpanContext,
+                getClass().getSimpleName());
+        TracingHelper.TAG_ADAPTER_INSTANCE_ID.set(currentSpan, adapterInstanceId);
+
+        final var commandContext = new PubSubBasedCommandContext(command, commandResponseSender, currentSpan);
+        return tenantClient.get(command.getTenant(), null)
+                .recover(t -> {
+                    log.warn("error retrieving tenant configuration [{}]", command);
+                    final var exception = new ServerErrorException(
+                            command.getTenant(),
+                            HttpURLConnection.HTTP_UNAVAILABLE,
+                            "error retrieving tenant configuration",
+                            t);
+                    commandContext.release(exception);
+                    return Future.failedFuture(exception);
+                })
+                .compose(tenantConfig -> {
+                    commandContext.put(CommandContext.KEY_TENANT_CONFIG, tenantConfig);
+                    if (commandHandler != null) {
+                        log.debug("using [{}] for received command [{}]", commandHandler, command);
+                        // command.isValid() check not done here - it is to be done in the command handler
+                        return commandHandler.handleCommand(commandContext);
+                    } else {
+                        log.info("no command handler found for command [{}]", command);
+                        final var exception = new NoConsumerException("no command handler found for command");
+                        commandContext.release(exception);
+                        return Future.failedFuture(exception);
+                    }
+                });
+    }
+
+    @Override
+    public Future<Void> stop() {
+        return lifecycleStatus.runStopAttempt(() -> CompositeFuture.all(
+                subscriberFactory.closeSubscriber(CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId),
+                adminClientManager.closeAdminClients()).mapEmpty());
+    }
+
+}

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSender.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSender.java
@@ -97,9 +97,8 @@ public class PubSubBasedInternalCommandSender extends AbstractPubSubBasedMessage
 
     private Map<String, Object> getAttributes(final PubSubBasedCommand command) {
         final Map<String, Object> attributes = new HashMap<>(command.getPubsubMessage().getAttributesMap());
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, command.getTenant());
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, command.getTenant());
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, command.getDeviceId());
+        attributes.put(MessageHelper.APP_PROPERTY_TENANT_ID, command.getTenant());
+        attributes.put(MessageHelper.APP_PROPERTY_DEVICE_ID, command.getDeviceId());
         attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
         attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, !command.isOneWay());
         Optional.ofNullable(command.getGatewayId()).ifPresent(

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSender.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSender.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.command.Command;
+import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.InternalCommandSender;
+import org.eclipse.hono.client.pubsub.AbstractPubSubBasedMessageSender;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+
+import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+
+/**
+ * A Pub/Sub based sender for sending commands to an internal command topic
+ * (<em>${adapterInstanceId}.command_internal</em>). Protocol adapters consume commands by subscribing to this topic.
+ */
+public class PubSubBasedInternalCommandSender extends AbstractPubSubBasedMessageSender implements
+        InternalCommandSender {
+
+    /**
+     * Creates a new Pub/Sub based internal command sender.
+     *
+     * @param publisherFactory The factory to use for creating Pub/Sub publishers.
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param tracer The OpenTracing tracer.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public PubSubBasedInternalCommandSender(
+            final PubSubPublisherFactory publisherFactory,
+            final String projectId,
+            final Tracer tracer) {
+        super(publisherFactory, CommandConstants.INTERNAL_COMMAND_ENDPOINT, projectId, tracer);
+    }
+
+    @Override
+    public Future<Void> sendCommand(
+            final CommandContext commandContext,
+            final String adapterInstanceId) {
+
+        Objects.requireNonNull(commandContext);
+        Objects.requireNonNull(adapterInstanceId);
+
+        final Command command = commandContext.getCommand();
+        if (!(command instanceof PubSubBasedCommand)) {
+            commandContext.release();
+            log.error("command is not an instance of PubSubBasedCommand");
+            throw new IllegalArgumentException("command is not an instance of PubSubBasedCommand");
+        }
+
+        final Span span = startSpan(
+                CommandConstants.INTERNAL_COMMAND_SPAN_OPERATION_NAME,
+                command.getTenant(),
+                command.getDeviceId(),
+                References.CHILD_OF,
+                commandContext.getTracingContext());
+        final String topic = PubSubMessageHelper.getTopicName(CommandConstants.INTERNAL_COMMAND_ENDPOINT,
+                adapterInstanceId);
+
+        return sendAndWaitForOutcome(
+                topic,
+                command.getTenant(),
+                command.getDeviceId(),
+                command.getPayload(),
+                getAttributes((PubSubBasedCommand) command),
+                span)
+                        .onSuccess(v -> commandContext.accept())
+                        .onFailure(thr -> commandContext.release(new ServerErrorException(
+                                command.getTenant(),
+                                HttpURLConnection.HTTP_UNAVAILABLE,
+                                "failed to publish command message on internal command topic",
+                                thr)))
+                        .onComplete(ar -> span.finish());
+    }
+
+    private Map<String, Object> getAttributes(final PubSubBasedCommand command) {
+        final Map<String, Object> attributes = new HashMap<>(command.getPubsubMessage().getAttributesMap());
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, command.getTenant());
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, command.getTenant());
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, command.getDeviceId());
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, !command.isOneWay());
+        Optional.ofNullable(command.getGatewayId()).ifPresent(
+                id -> attributes.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, id));
+        return attributes;
+    }
+}

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContextTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContextTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.command.CommandResponse;
+import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Span;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+
+/**
+ * Verifies behavior of {@link PubSubBasedCommandContext}.
+ *
+ */
+public class PubSubBasedCommandContextTest {
+
+    private CommandResponseSender responseSender;
+
+    @BeforeEach
+    void setUp() {
+        responseSender = mock(CommandResponseSender.class);
+        when(responseSender.sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                any()))
+                        .thenReturn(Future.succeededFuture());
+    }
+
+    @Test
+    void testErrorIsSendOnCommandResponseTopicWhenContextGetsRejected() {
+        testErrorIsSentOnCommandResponseTopic(
+                context -> context.reject(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST)),
+                commandResponse -> assertThat(commandResponse.getStatus())
+                        .isEqualTo(HttpURLConnection.HTTP_BAD_REQUEST));
+    }
+
+    @Test
+    void testErrorIsSendOnCommandResponseTopicWhenContextGetsReleased() {
+        testErrorIsSentOnCommandResponseTopic(
+                context -> context.release(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST)),
+                commandResponse -> assertThat(commandResponse.getStatus())
+                        .isEqualTo(HttpURLConnection.HTTP_UNAVAILABLE));
+    }
+
+    @Test
+    void testErrorIsSendOnCommandResponseTopicWhenContextGetsModified() {
+        testErrorIsSentOnCommandResponseTopic(
+                context -> context.modify(true, true),
+                commandResponse -> assertThat(commandResponse.getStatus())
+                        .isEqualTo(HttpURLConnection.HTTP_NOT_FOUND));
+    }
+
+    @Test
+    void testNoErrorIsSendOnCommandResponseTopicWhenContextGetsAccepted() {
+        final var command = getRequestResponseCommand();
+        final Span span = TracingMockSupport.mockSpan();
+        final var context = new PubSubBasedCommandContext(command, responseSender, span);
+        context.accept();
+        verify(span).finish();
+    }
+
+    private void testErrorIsSentOnCommandResponseTopic(
+            final Consumer<PubSubBasedCommandContext> contextHandler,
+            final Consumer<CommandResponse> responseAssertions) {
+
+        final var command = getRequestResponseCommand();
+        final var context = new PubSubBasedCommandContext(command, responseSender, NoopSpan.INSTANCE);
+        contextHandler.accept(context);
+
+        final ArgumentCaptor<CommandResponse> commandResponse = ArgumentCaptor.forClass(CommandResponse.class);
+        verify(responseSender).sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                commandResponse.capture(),
+                any());
+        assertThat(commandResponse.getValue().getCorrelationId()).isEqualTo("my-correlation-id");
+        responseAssertions.accept(commandResponse.getValue());
+    }
+
+    private PubSubBasedCommand getRequestResponseCommand() {
+
+        final String correlationId = "my-correlation-id";
+        final String deviceId = "test-device";
+        final String tenantId = "test-tenant";
+        final String subject = "test-subject";
+        final String responseRequired = "true";
+
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId);
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId);
+        attributes.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject);
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, responseRequired);
+        attributes.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId);
+
+        final PubsubMessage message = PubsubMessage.newBuilder().putAllAttributes(attributes).build();
+        return PubSubBasedCommand.from(message, tenantId);
+    }
+}

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContextTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandContextTest.java
@@ -62,7 +62,7 @@ public class PubSubBasedCommandContextTest {
     }
 
     @Test
-    void testErrorIsSendOnCommandResponseTopicWhenContextGetsRejected() {
+    void testErrorIsSentOnCommandResponseTopicWhenContextGetsRejected() {
         testErrorIsSentOnCommandResponseTopic(
                 context -> context.reject(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST)),
                 commandResponse -> assertThat(commandResponse.getStatus())
@@ -70,7 +70,7 @@ public class PubSubBasedCommandContextTest {
     }
 
     @Test
-    void testErrorIsSendOnCommandResponseTopicWhenContextGetsReleased() {
+    void testErrorIsSentOnCommandResponseTopicWhenContextGetsReleased() {
         testErrorIsSentOnCommandResponseTopic(
                 context -> context.release(new ClientErrorException(HttpURLConnection.HTTP_BAD_REQUEST)),
                 commandResponse -> assertThat(commandResponse.getStatus())
@@ -78,7 +78,7 @@ public class PubSubBasedCommandContextTest {
     }
 
     @Test
-    void testErrorIsSendOnCommandResponseTopicWhenContextGetsModified() {
+    void testErrorIsSentOnCommandResponseTopicWhenContextGetsModified() {
         testErrorIsSentOnCommandResponseTopic(
                 context -> context.modify(true, true),
                 commandResponse -> assertThat(commandResponse.getStatus())
@@ -86,7 +86,7 @@ public class PubSubBasedCommandContextTest {
     }
 
     @Test
-    void testNoErrorIsSendOnCommandResponseTopicWhenContextGetsAccepted() {
+    void testNoErrorIsSentOnCommandResponseTopicWhenContextGetsAccepted() {
         final var command = getRequestResponseCommand();
         final Span span = TracingMockSupport.mockSpan();
         final var context = new PubSubBasedCommandContext(command, responseSender, span);
@@ -121,8 +121,8 @@ public class PubSubBasedCommandContextTest {
         final String responseRequired = "true";
 
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId);
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId);
+        attributes.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
+        attributes.put(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
         attributes.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject);
         attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, responseRequired);
         attributes.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId);

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandResponseSenderTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandResponseSenderTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.eclipse.hono.client.command.CommandResponse;
+import org.eclipse.hono.client.command.Commands;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherClient;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessagingType;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.ResourceLimits;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Tracer;
+import io.opentracing.noop.NoopSpan;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.EventBus;
+
+/**
+ * Verifies behavior of {@link PubSubBasedCommandResponseSender}.
+ */
+public class PubSubBasedCommandResponseSenderTest {
+
+    private final String projectId = "test-project";
+
+    private Vertx vertx;
+    private Tracer tracer;
+
+    private PubSubPublisherFactory factory;
+    private PubSubPublisherClient client;
+    private PubSubBasedCommandResponseSender commandResponseSender;
+
+    @BeforeEach
+    void setUp() {
+        vertx = mock(Vertx.class);
+        when(vertx.eventBus()).thenReturn(mock(EventBus.class));
+
+        tracer = TracingMockSupport.mockTracer(TracingMockSupport.mockSpan());
+        client = mock(PubSubPublisherClient.class);
+        factory = mock(PubSubPublisherFactory.class);
+    }
+
+    @Test
+    void testIfValidCommandResponseIsSent() {
+        final String correlationId = "my-correlation-id";
+        final String deviceId = "test-device";
+        final String tenantId = "test-tenant";
+        final String contentType = "text/plain";
+        final String payload = "test-payload";
+        final String topic = String.format("%s.%s", tenantId, CommandConstants.COMMAND_RESPONSE_ENDPOINT);
+        final int status = 200;
+
+        final CommandResponse commandResponse = CommandResponse.fromAddressAndCorrelationId(
+                String.format("%s/%s/%s", CommandConstants.COMMAND_RESPONSE_ENDPOINT, tenantId,
+                        Commands.getDeviceFacingReplyToId("", deviceId, MessagingType.pubsub)),
+                correlationId,
+                Buffer.buffer(payload),
+                contentType,
+                status);
+
+        final TenantObject tenantObject = TenantObject.from(tenantId);
+        tenantObject.setResourceLimits(new ResourceLimits().setMaxTtlCommandResponse(10L));
+
+        when(client.publish(any(PubsubMessage.class))).thenReturn(Future.succeededFuture());
+        when(factory.getOrCreatePublisher(topic)).thenReturn(client);
+        commandResponseSender = new PubSubBasedCommandResponseSender(vertx, factory, projectId, tracer);
+        commandResponseSender.start();
+
+        final Future<Void> result = commandResponseSender.sendCommandResponse(
+                tenantObject,
+                new RegistrationAssertion(deviceId),
+                commandResponse,
+                NoopSpan.INSTANCE.context());
+
+        assertThat(result.succeeded()).isTrue();
+        verify(client).publish(any(PubsubMessage.class));
+    }
+}

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandTest.java
@@ -168,9 +168,9 @@ public class PubSubBasedCommandTest {
             final String correlationId, final String responseRequired, final String via) {
         final Map<String, String> attributes = new HashMap<>();
         Optional.ofNullable(deviceId)
-                .ifPresent(ok -> attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId));
+                .ifPresent(ok -> attributes.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId));
         Optional.ofNullable(tenantId)
-                .ifPresent(ok -> attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId));
+                .ifPresent(ok -> attributes.put( MessageHelper.APP_PROPERTY_TENANT_ID, tenantId));
         Optional.ofNullable(subject)
                 .ifPresent(ok -> attributes.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject));
         Optional.ofNullable(responseRequired)

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedCommandTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.util.MessageHelper;
+import org.junit.jupiter.api.Test;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+/**
+ * Verifies behavior of {@link PubSubBasedCommand}.
+ *
+ */
+public class PubSubBasedCommandTest {
+
+    private final String correlationId = "my-correlation-id";
+    private final String deviceId = "test-device";
+    private final String tenantId = "test-tenant";
+    private final String subject = "test-subject";
+
+    /**
+     * Verifies that a command can be created from a valid PubsubMessage.
+     */
+    @Test
+    public void testFromMessageSucceeds() {
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, subject, null, null, null);
+
+        final PubSubBasedCommand command = PubSubBasedCommand.from(message, tenantId);
+        assertTrue(command.isValid());
+        assertThat(command.getName()).isEqualTo(subject);
+        assertThat(command.getDeviceId()).isEqualTo(deviceId);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo(deviceId);
+        assertThat(command.getGatewayId()).isNull();
+        assertThat(command.getCorrelationId()).isNull();
+        assertTrue(command.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid PubsubMessage that represent a request/response command.
+     */
+    @Test
+    public void testFromMessageSucceedsForRequestResponseCommand() {
+        final String responseRequired = "true";
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, subject, correlationId, responseRequired,
+                null);
+
+        final PubSubBasedCommand command = PubSubBasedCommand.from(message, tenantId);
+        assertTrue(command.isValid());
+        assertThat(command.getName()).isEqualTo(subject);
+        assertThat(command.getDeviceId()).isEqualTo(deviceId);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo(deviceId);
+        assertThat(command.getGatewayId()).isNull();
+        assertThat(command.getCorrelationId()).isEqualTo(correlationId);
+        assertFalse(command.isOneWay());
+    }
+
+    /**
+     * Verifies that a command can be created from a valid PubsubMessage representing a routed command message with a
+     * via attribute containing the gateway identifier.
+     */
+    @Test
+    public void testFromRoutedMessageSucceeds() {
+        final String gatewayId = "test-gateway";
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, subject, correlationId, null,
+                gatewayId);
+
+        final PubSubBasedCommand command = PubSubBasedCommand.fromRoutedCommandMessage(message);
+        assertTrue(command.isValid());
+        assertThat(command.getName()).isEqualTo(subject);
+        assertThat(command.getDeviceId()).isEqualTo(deviceId);
+        assertThat(command.getGatewayOrDeviceId()).isEqualTo(gatewayId);
+        assertThat(command.getGatewayId()).isEqualTo(gatewayId);
+        assertThat(command.getCorrelationId()).isEqualTo(correlationId);
+        assertTrue(command.isOneWay());
+    }
+
+    /**
+     * Verifies that a command cannot be created from a PubsubMessage that contains an empty attributes map.
+     */
+    @Test
+    public void testFromRoutedMessageFailsForEmptyAttributes() {
+        final PubsubMessage message = getPubSubMessage(null, null, null, null, null,
+                null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            PubSubBasedCommand.fromRoutedCommandMessage(message);
+        });
+    }
+
+    /**
+     * Verifies that a command cannot be created from a PubsubMessage that doesn't contain a tenant_id attribute.
+     */
+    @Test
+    public void testFromRoutedMessageFailsForMissingTenantId() {
+        final PubsubMessage message = getPubSubMessage(null, deviceId, subject, null, null,
+                null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            PubSubBasedCommand.fromRoutedCommandMessage(message);
+        });
+    }
+
+    /**
+     * Verifies that a command cannot be created from a PubsubMessage that doesn't contain a device_id attribute.
+     */
+    @Test
+    public void testFromRoutedMessageFailsForMissingDeviceId() {
+        final PubsubMessage message = getPubSubMessage(tenantId, null, subject, null, null,
+                null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            PubSubBasedCommand.fromRoutedCommandMessage(message);
+        });
+    }
+
+    /**
+     * Verifies that an invalid command is created from a PubsubMessage that does not contain a correlation-id attribute
+     * but has response-required set to true.
+     */
+    @Test
+    public void testFromMessageFailsForMissingCorrelationIdWithResponseRequired() {
+        final String responseRequired = "true";
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, subject, null, responseRequired,
+                null);
+
+        final PubSubBasedCommand command = PubSubBasedCommand.from(message, tenantId);
+
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("correlation-id is not set");
+    }
+
+    /**
+     * Verifies that an invalid command is created from a PubsubMessage that doesn't contain a subject attribute.
+     */
+    @Test
+    public void testFromMessageFailsForMessageWithoutSubject() {
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, null, null, null,
+                null);
+
+        final PubSubBasedCommand command = PubSubBasedCommand.from(message, tenantId);
+
+        assertFalse(command.isValid());
+        assertThat(command.getInvalidCommandReason()).contains("subject not set");
+    }
+
+    private PubsubMessage getPubSubMessage(final String tenantId, final String deviceId, final String subject,
+            final String correlationId, final String responseRequired, final String via) {
+        final Map<String, String> attributes = new HashMap<>();
+        Optional.ofNullable(deviceId)
+                .ifPresent(ok -> attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId));
+        Optional.ofNullable(tenantId)
+                .ifPresent(ok -> attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId));
+        Optional.ofNullable(subject)
+                .ifPresent(ok -> attributes.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject));
+        Optional.ofNullable(responseRequired)
+                .ifPresent(ok -> attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, responseRequired));
+        Optional.ofNullable(correlationId)
+                .ifPresent(ok -> attributes.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, correlationId));
+        Optional.ofNullable(via)
+                .ifPresent(ok -> attributes.put(MessageHelper.APP_PROPERTY_CMD_VIA, via));
+
+        return PubsubMessage.newBuilder().putAllAttributes(attributes).build();
+    }
+}

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumerTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumerTest.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.CommandHandlers;
+import org.eclipse.hono.client.command.CommandResponse;
+import org.eclipse.hono.client.command.CommandResponseSender;
+import org.eclipse.hono.client.pubsub.PubSubBasedAdminClientManager;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.client.pubsub.subscriber.PubSubSubscriberClient;
+import org.eclipse.hono.client.pubsub.subscriber.PubSubSubscriberFactory;
+import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.client.util.StatusCodeMapper;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Tracer;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * Verifies behavior of {@link PubSubBasedInternalCommandConsumer}.
+ */
+public class PubSubBasedInternalCommandConsumerTest {
+
+    private final String deviceId = "test-device";
+    private final String tenantId = "test-tenant";
+    private final String subject = "test-subject";
+
+    private final String adapterInstanceId = "test-adapter";
+
+    private final String subscription = String.format("%s.%s", adapterInstanceId,
+            CommandConstants.INTERNAL_COMMAND_ENDPOINT);
+
+    private PubSubSubscriberClient subscriber;
+
+    private CommandResponseSender commandResponseSender;
+
+    private CommandHandlers commandHandlers;
+
+    private TenantClient tenantClient;
+
+    private PubSubBasedInternalCommandConsumer internalCommandConsumer;
+
+    @BeforeEach
+    void setUp() {
+        commandResponseSender = mock(CommandResponseSender.class);
+
+        final Tracer tracer = TracingMockSupport.mockTracer(TracingMockSupport.mockSpan());
+        commandHandlers = new CommandHandlers();
+        tenantClient = mock(TenantClient.class);
+
+        doAnswer(invocation -> {
+            final String tenantId = invocation.getArgument(0);
+            return Future.succeededFuture(TenantObject.from(tenantId));
+        }).when(tenantClient).get(anyString(), any());
+
+        when(commandResponseSender.sendCommandResponse(
+                any(TenantObject.class),
+                any(RegistrationAssertion.class),
+                any(CommandResponse.class),
+                any())).thenReturn(Future.succeededFuture());
+
+        final PubSubBasedAdminClientManager adminClientManager = mock(PubSubBasedAdminClientManager.class);
+        when(adminClientManager
+                .getOrCreateTopicAndSubscription(CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId))
+                        .thenReturn(Future.succeededFuture(subscription));
+
+        subscriber = mock(PubSubSubscriberClient.class);
+        when(subscriber.subscribe(true)).thenReturn(Future.succeededFuture());
+
+        final MessageReceiver receiver = mock(MessageReceiver.class);
+        final PubSubSubscriberFactory subscriberFactory = mock(PubSubSubscriberFactory.class);
+        when(subscriberFactory.getOrCreateSubscriber(subscription, receiver))
+                .thenReturn(subscriber);
+
+        internalCommandConsumer = new PubSubBasedInternalCommandConsumer(
+                commandResponseSender,
+                adapterInstanceId,
+                commandHandlers,
+                tenantClient,
+                tracer,
+                subscriberFactory,
+                adminClientManager,
+                receiver);
+
+    }
+
+    /**
+     * Verifies that the subscriber is subscribing when PubSubBasedInternalCommandConsumer is started.
+     */
+    @Test
+    public void testThatSubscriberSubscribesOnStart() {
+        internalCommandConsumer.start();
+        verify(subscriber).subscribe(true);
+    }
+
+    /**
+     * Verifies that an error response is sent to the application if the tenant of the target device is unknown or
+     * cannot be retrieved.
+     */
+    @Test
+    public void testHandleCommandMessageSendErrorResponse() {
+        final PubsubMessage message = getPubSubMessage(subject, "true");
+        final Function<CommandContext, Future<Void>> commandHandler = mock(Function.class);
+        final Context context = VertxMockSupport.mockContext(mock(Vertx.class));
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler, context);
+
+        when(tenantClient.get(eq(tenantId), any())).thenReturn(
+                Future.failedFuture(
+                        StatusCodeMapper.from(HttpURLConnection.HTTP_UNAVAILABLE, "failed to retrieve tenant")));
+
+        internalCommandConsumer.handleCommandMessage(message);
+        verify(commandHandler, never()).apply(any(PubSubBasedCommandContext.class));
+        verify(commandResponseSender).sendCommandResponse(
+                argThat(t -> t.getTenantId().equals(tenantId)),
+                argThat(r -> r.getDeviceId().equals(deviceId)),
+                argThat(cr -> cr.getStatus() == HttpURLConnection.HTTP_UNAVAILABLE),
+                any());
+    }
+
+    /**
+     * Verifies that the consumer handles an invalid command message with missing subject by invoking the matching handler.
+     */
+    @Test
+    public void testHandleCommandMessageWithInvalidAttribute() {
+        final PubsubMessage message = getPubSubMessage(null, "true");
+        final Function<CommandContext, Future<Void>> commandHandler = mock(Function.class);
+        final Context context = VertxMockSupport.mockContext(mock(Vertx.class));
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler, context);
+
+        internalCommandConsumer.handleCommandMessage(message);
+
+        final ArgumentCaptor<CommandContext> commandContextArgumentCaptor = ArgumentCaptor
+                .forClass(CommandContext.class);
+        verify(commandHandler).apply(commandContextArgumentCaptor.capture());
+        assertThat(commandContextArgumentCaptor.getValue()).isNotNull();
+        assertThat(commandContextArgumentCaptor.getValue().getCommand().isValid()).isFalse();
+        assertThat(commandContextArgumentCaptor.getValue().getCommand().getInvalidCommandReason())
+                .contains("subject not set");
+    }
+
+    /**
+     * Verifies that the consumer handles a valid message by invoking the matching command handler.
+     */
+    @Test
+    public void testHandleCommandMessageWithHandlerForDevice() {
+        final PubsubMessage message = getPubSubMessage(subject, "false");
+        final Function<CommandContext, Future<Void>> commandHandler = mock(Function.class);
+        final Context context = VertxMockSupport.mockContext(mock(Vertx.class));
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler, context);
+
+        internalCommandConsumer.handleCommandMessage(message);
+
+        final ArgumentCaptor<CommandContext> commandContextArgumentCaptor = ArgumentCaptor
+                .forClass(CommandContext.class);
+        verify(commandHandler).apply(commandContextArgumentCaptor.capture());
+        assertThat(commandContextArgumentCaptor.getValue()).isNotNull();
+        assertThat(commandContextArgumentCaptor.getValue().getCommand().isValid()).isTrue();
+    }
+
+    /**
+     * Verifies that an error response is sent to the application if no command handler can be found for command.
+     */
+    @Test
+    public void testHandleCommandMessageWithNoHandlerForDevice() {
+        final PubsubMessage message = getPubSubMessage(subject, "true");
+        final Function<CommandContext, Future<Void>> commandHandler = mock(Function.class);
+
+        internalCommandConsumer.handleCommandMessage(message);
+        verify(commandHandler, never()).apply(any(PubSubBasedCommandContext.class));
+        verify(commandResponseSender).sendCommandResponse(
+                argThat(t -> t.getTenantId().equals(tenantId)),
+                argThat(r -> r.getDeviceId().equals(deviceId)),
+                argThat(cr -> cr.getStatus() == HttpURLConnection.HTTP_UNAVAILABLE),
+                any());
+    }
+
+    /**
+     * Verifies that a failed future is returned if an IllegalArgumentException is thrown when no command can be
+     * created by the PubSubMessage.
+     */
+    @Test
+    public void testHandleCommandMessageFailedWhenMessageContainsNoAttributes() {
+        final PubsubMessage message = PubsubMessage.newBuilder().putAllAttributes(Collections.emptyMap()).build();
+        final Function<CommandContext, Future<Void>> commandHandler = mock(Function.class);
+        final Context context = VertxMockSupport.mockContext(mock(Vertx.class));
+        commandHandlers.putCommandHandler(tenantId, deviceId, null, commandHandler, context);
+
+        final Future<Void> result = internalCommandConsumer.handleCommandMessage(message);
+        assertThat(result.failed()).isTrue();
+    }
+
+    private PubsubMessage getPubSubMessage(final String subject, final String responseRequired) {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId);
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId);
+        attributes.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, "my-correlation-id");
+
+        Optional.ofNullable(subject)
+                .ifPresent(ok -> attributes.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject));
+        Optional.ofNullable(responseRequired)
+                .ifPresent(ok -> attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, responseRequired));
+
+        return PubsubMessage.newBuilder().putAllAttributes(attributes).build();
+    }
+
+}

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumerTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumerTest.java
@@ -234,8 +234,8 @@ public class PubSubBasedInternalCommandConsumerTest {
 
     private PubsubMessage getPubSubMessage(final String subject, final String responseRequired) {
         final Map<String, String> attributes = new HashMap<>();
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId);
-        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId);
+        attributes.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId);
+        attributes.put(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId);
         attributes.put(MessageHelper.SYS_PROPERTY_CORRELATION_ID, "my-correlation-id");
 
         Optional.ofNullable(subject)

--- a/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSenderTest.java
+++ b/clients/command-pubsub/src/test/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSenderTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command.pubsub;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.hono.client.command.Command;
+import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherClient;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.util.CommandConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Tracer;
+import io.vertx.core.Future;
+import io.vertx.core.buffer.Buffer;
+
+/**
+ * Verifies behavior of {@link PubSubBasedInternalCommandSender}.
+ */
+public class PubSubBasedInternalCommandSenderTest {
+
+    private final String adapterInstanceId = "test-adapter";
+
+    private final String deviceId = "test-device";
+
+    private final String tenantId = "test-tenant";
+
+    private PubSubPublisherFactory factory;
+
+    private PubSubBasedInternalCommandSender internalCommandSender;
+
+    @BeforeEach
+    void setUp() {
+        factory = mock(PubSubPublisherFactory.class);
+        final Tracer tracer = TracingMockSupport.mockTracer(TracingMockSupport.mockSpan());
+        final String projectId = "test-project";
+        internalCommandSender = new PubSubBasedInternalCommandSender(factory, projectId, tracer);
+    }
+
+    @Test
+    void testThatErrorIsThrownWhenCommandIsNotPubSubBasedCommand() {
+        final Command command = mock(Command.class);
+        final CommandContext commandContext = mock(CommandContext.class);
+        when(commandContext.getCommand()).thenReturn(command);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> internalCommandSender.sendCommand(commandContext, adapterInstanceId));
+    }
+
+    @Test
+    void testThatCommandIsSendSuccessfully() {
+        final PubSubPublisherClient client = mock(PubSubPublisherClient.class);
+        when(client.publish(any(PubsubMessage.class))).thenReturn(Future.succeededFuture());
+
+        final String topic = String.format("%s.%s", adapterInstanceId, CommandConstants.INTERNAL_COMMAND_ENDPOINT);
+        when(factory.getOrCreatePublisher(topic)).thenReturn(client);
+
+        final PubSubBasedCommand command = mock(PubSubBasedCommand.class);
+        final PubsubMessage message = getPubSubMessage();
+        when(command.getTenant()).thenReturn(tenantId);
+        when(command.getDeviceId()).thenReturn(deviceId);
+        when(command.getPayload()).thenReturn(Buffer.buffer("test payload"));
+        when(command.getPubsubMessage()).thenReturn(message);
+
+        final CommandContext commandContext = mock(CommandContext.class);
+        when(commandContext.getCommand()).thenReturn(command);
+
+        internalCommandSender.start();
+        final Future<Void> result = internalCommandSender.sendCommand(commandContext, adapterInstanceId);
+
+        assertThat(result.succeeded()).isTrue();
+        verify(commandContext).accept();
+        verify(client).publish(any(PubsubMessage.class));
+    }
+
+    private PubsubMessage getPubSubMessage() {
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, deviceId);
+        attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, tenantId);
+
+        return PubsubMessage.newBuilder().putAllAttributes(attributes).build();
+    }
+
+}

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/AbstractCommandContext.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/AbstractCommandContext.java
@@ -34,12 +34,13 @@ import io.vertx.core.json.JsonObject;
 /**
  * A base class providing utility methods for passing around parameters relevant for processing a {@code Command} used
  * in a Pub/Sub and Kafka based command context.
+ * @param <T> The type of Command.
  */
-public abstract class AbstractCommandContext extends MapBasedExecutionContext implements CommandContext {
+public abstract class AbstractCommandContext<T extends Command> extends MapBasedExecutionContext implements CommandContext {
 
     protected static final Logger LOG = LoggerFactory.getLogger(AbstractCommandContext.class);
 
-    protected final Command command;
+    protected final T command;
 
     private final CommandResponseSender commandResponseSender;
 
@@ -55,7 +56,7 @@ public abstract class AbstractCommandContext extends MapBasedExecutionContext im
      */
     public AbstractCommandContext(
             final Span span,
-            final Command command,
+            final T command,
             final CommandResponseSender commandResponseSender) {
         super(span);
         this.command = Objects.requireNonNull(command);
@@ -73,7 +74,7 @@ public abstract class AbstractCommandContext extends MapBasedExecutionContext im
     }
 
     @Override
-    public Command getCommand() {
+    public T getCommand() {
         return command;
     }
 

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/AbstractCommandContext.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/AbstractCommandContext.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.command;
+
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.MapBasedExecutionContext;
+import org.eclipse.hono.util.MessagingType;
+import org.eclipse.hono.util.RegistrationAssertion;
+import org.eclipse.hono.util.TenantObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A base class providing utility methods for passing around parameters relevant for processing a {@code Command} used
+ * in a Pub/Sub and Kafka based command context.
+ */
+public abstract class AbstractCommandContext extends MapBasedExecutionContext implements CommandContext {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(AbstractCommandContext.class);
+
+    protected final Command command;
+
+    private final CommandResponseSender commandResponseSender;
+
+    private String completedOutcome;
+
+    /**
+     * Creates a new command context instance.
+     *
+     * @param span The OpenTracing span to use for tracking the processing of the command.
+     * @param command The command to be processed.
+     * @param commandResponseSender The sender used to send a command response.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public AbstractCommandContext(
+            final Span span,
+            final Command command,
+            final CommandResponseSender commandResponseSender) {
+        super(span);
+        this.command = Objects.requireNonNull(command);
+        this.commandResponseSender = Objects.requireNonNull(commandResponseSender);
+    }
+
+    @Override
+    public final boolean isCompleted() {
+        return completedOutcome != null;
+    }
+
+    @Override
+    public void logCommandToSpan(final Span span) {
+        command.logToSpan(span);
+    }
+
+    @Override
+    public Command getCommand() {
+        return command;
+    }
+
+    @Override
+    public void accept() {
+        if (!setCompleted(OUTCOME_ACCEPTED)) {
+            return;
+        }
+        final Span span = getTracingSpan();
+        LOG.debug("accepted command message [{}]", getCommand());
+        Tags.HTTP_STATUS.set(span, HttpURLConnection.HTTP_ACCEPTED);
+        span.log("command for device handled with outcome 'accepted'");
+        span.finish();
+    }
+
+    /**
+     * Sets the outcome of a command context if it is not already completed with another outcome.
+     *
+     * @param outcome The outcome of the command context.
+     * @return True if the outcome is set successfully, false if it has been already completed.
+     */
+    protected boolean setCompleted(final String outcome) {
+        if (completedOutcome != null) {
+            LOG.warn("can't apply '{}' outcome, context already completed with '{}' outcome [{}]",
+                    outcome, completedOutcome, getCommand());
+            return false;
+        }
+        completedOutcome = outcome;
+        return true;
+    }
+
+    /**
+     * Checks if the command is a request-response command.
+     *
+     * @return True if it is a request-response command, false otherwise.
+     */
+    protected boolean isRequestResponseCommand() {
+        return !command.isOneWay();
+    }
+
+    /**
+     * Sends a command response if the command response message represents an error message.
+     *
+     * @param status The HTTP status code indicating the outcome of processing the command.
+     * @param error The error message describing the cause for the command message delivery failure.
+     * @param span The active OpenTracing span to use for tracking this operation.
+     * @param cause The delivery error.
+     * @param correlationId The correlation ID of the command that this is the response for.
+     * @param messagingType The type of the messaging system via which the command message was received.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the command response has been sent.
+     *         <p>
+     *         The future will be failed if the command response could not be sent.
+     */
+    protected Future<Void> sendDeliveryFailureCommandResponseMessage(
+            final int status,
+            final String error,
+            final Span span,
+            final Throwable cause,
+            final String correlationId,
+            final MessagingType messagingType) {
+        if (correlationId == null) {
+            TracingHelper.logError(span, "can't send command response message - no correlation id set");
+            return Future.failedFuture("missing correlation id");
+        }
+
+        final JsonObject payloadJson = new JsonObject();
+        payloadJson.put("error", error != null ? error : "");
+
+        final CommandResponse commandResponse = new CommandResponse(
+                command.getTenant(),
+                command.getDeviceId(),
+                payloadJson.toBuffer(),
+                CommandConstants.CONTENT_TYPE_DELIVERY_FAILURE_NOTIFICATION,
+                status,
+                correlationId,
+                "",
+                messagingType);
+        commandResponse.setAdditionalProperties(
+                Collections.unmodifiableMap(command.getDeliveryFailureNotificationProperties()));
+
+        return commandResponseSender.sendCommandResponse(
+                // try to retrieve tenant configuration from context
+                Optional.ofNullable(get(KEY_TENANT_CONFIG))
+                        .filter(TenantObject.class::isInstance)
+                        .map(TenantObject.class::cast)
+                        // and fall back to default configuration
+                        .orElseGet(() -> TenantObject.from(command.getTenant())),
+                new RegistrationAssertion(command.getDeviceId()),
+                commandResponse,
+                span.context())
+                .onFailure(thr -> {
+                    LOG.debug("failed to publish command response [{}]", commandResponse, thr);
+                    TracingHelper.logError(span, "failed to publish command response message", thr);
+                })
+                .onSuccess(v -> {
+                    LOG.debug("published error command response [{}, cause: {}]", commandResponse,
+                            cause != null ? cause.getMessage() : error);
+                    span.log("published error command response");
+                });
+    }
+}

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Command.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Command.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.hono.client.command;
 
+import java.util.Map;
+
 import org.eclipse.hono.util.MessagingType;
 
 import io.opentracing.Span;
@@ -185,4 +187,11 @@ public interface Command {
      * @throws NullPointerException if span is {@code null}.
      */
     void logToSpan(Span span);
+
+    /**
+     * Gets the set of properties to be set on the command response message if delivery of this command fails.
+     *
+     * @return The properties.
+     */
+    Map<String, String> getDeliveryFailureNotificationProperties();
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandContext.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandContext.java
@@ -41,6 +41,26 @@ public interface CommandContext extends ExecutionContext {
     String KEY_TENANT_CONFIG = "tenant-config";
 
     /**
+     * The outcome of an accepted command context.
+     */
+    String ACCEPTED_COMMAND_CONTEXT = "accepted";
+
+    /**
+     * The outcome of a released command context.
+     */
+    String RELEASED_COMMAND_CONTEXT = "released";
+
+    /**
+     * The outcome of a modified command context.
+     */
+    String MODIFIED_COMMAND_CONTEXT = "modified";
+
+    /**
+     * The outcome of a rejected command context.
+     */
+    String REJECTED_COMMAND_CONTEXT = "rejected";
+
+    /**
      * Checks if the context has already been completed.
      *
      * @return {@code true} if the context has already been completed.

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/CommandContext.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/CommandContext.java
@@ -43,22 +43,22 @@ public interface CommandContext extends ExecutionContext {
     /**
      * The outcome of an accepted command context.
      */
-    String ACCEPTED_COMMAND_CONTEXT = "accepted";
+    String OUTCOME_ACCEPTED = "accepted";
 
     /**
      * The outcome of a released command context.
      */
-    String RELEASED_COMMAND_CONTEXT = "released";
+    String OUTCOME_RELEASED = "released";
 
     /**
      * The outcome of a modified command context.
      */
-    String MODIFIED_COMMAND_CONTEXT = "modified";
+    String OUTCOME_MODIFIED = "modified";
 
     /**
      * The outcome of a rejected command context.
      */
-    String REJECTED_COMMAND_CONTEXT = "rejected";
+    String OUTCOME_REJECTED = "rejected";
 
     /**
      * Checks if the context has already been completed.

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
@@ -222,10 +222,14 @@ public final class Commands {
     }
 
     private static int getMessagingTypeIndex(final MessagingType messagingType) {
-        return messagingType.equals(MessagingType.kafka) ? 1 : 0;
+        return MessagingType.valueOf(messagingType.name()).ordinal();
     }
 
     private static MessagingType getMessagingTypeFromIndex(final int messagingTypeIndex) {
-        return messagingTypeIndex == 1 ? MessagingType.kafka : MessagingType.amqp;
+        return switch (messagingTypeIndex) {
+            case 0 -> MessagingType.amqp;
+            case 2 -> MessagingType.pubsub;
+            default -> MessagingType.kafka;
+        };
     }
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
@@ -33,7 +33,7 @@ public final class Commands {
     private static final byte BITFLAG_INDEX_REPLY_TO_CONTAINED_DEVICE_ID = 0;
     /**
      * Bit flag index for the index of the messaging type used for sending a command message.
-     * <p>The messaging type is encoded in three bits for now.
+     * <p>The messaging type is encoded in two bits for now.
      */
     private static final byte BITFLAG_INDEX_MESSAGING_TYPE = 1;
 

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
@@ -218,18 +218,18 @@ public final class Commands {
         // currently only encoding 2 messaging types here (BITFLAG_WIDTH_MESSAGING_TYPE is 1)
 //        return IntStream.range(BITFLAG_INDEX_MESSAGING_TYPE, BITFLAG_INDEX_MESSAGING_TYPE + BITFLAG_WIDTH_MESSAGING_TYPE)
 //                .reduce(0, (mask, index) -> mask | (1 << index));
-        return 1 << BITFLAG_INDEX_MESSAGING_TYPE;
+        return 3 << BITFLAG_INDEX_MESSAGING_TYPE;
     }
 
     private static int getMessagingTypeIndex(final MessagingType messagingType) {
-        return MessagingType.valueOf(messagingType.name()).ordinal();
+        return messagingType.ordinal();
     }
 
     private static MessagingType getMessagingTypeFromIndex(final int messagingTypeIndex) {
-        return switch (messagingTypeIndex) {
-            case 0 -> MessagingType.amqp;
-            case 2 -> MessagingType.pubsub;
-            default -> MessagingType.kafka;
-        };
+        try {
+            return MessagingType.values()[messagingTypeIndex];
+        } catch (final IndexOutOfBoundsException e) {
+            return MessagingType.amqp;
+        }
     }
 }

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/Commands.java
@@ -33,7 +33,7 @@ public final class Commands {
     private static final byte BITFLAG_INDEX_REPLY_TO_CONTAINED_DEVICE_ID = 0;
     /**
      * Bit flag index for the index of the messaging type used for sending a command message.
-     * <p>The messaging type is encoded in one bit for now.
+     * <p>The messaging type is encoded in three bits for now.
      */
     private static final byte BITFLAG_INDEX_MESSAGING_TYPE = 1;
 
@@ -215,9 +215,6 @@ public final class Commands {
     }
 
     private static int getMessagingTypeBitmask() {
-        // currently only encoding 2 messaging types here (BITFLAG_WIDTH_MESSAGING_TYPE is 1)
-//        return IntStream.range(BITFLAG_INDEX_MESSAGING_TYPE, BITFLAG_INDEX_MESSAGING_TYPE + BITFLAG_WIDTH_MESSAGING_TYPE)
-//                .reduce(0, (mask, index) -> mask | (1 << index));
         return 3 << BITFLAG_INDEX_MESSAGING_TYPE;
     }
 

--- a/clients/command/src/test/java/org/eclipse/hono/client/command/CommandsTest.java
+++ b/clients/command/src/test/java/org/eclipse/hono/client/command/CommandsTest.java
@@ -66,6 +66,26 @@ public class CommandsTest {
     }
 
     /**
+     * Verifies that getting the request id with non-empty parameters and messaging type Pub/Sub returns the expected value.
+     */
+    @Test
+    public void testEncodeRequestIdParametersWithMessagingTypePubSub() {
+        final String correlationId = "myCorrelationId";
+        final String replyToId = "myReplyToId";
+        final String deviceId = "myDeviceId";
+        final String requestId = Commands.encodeRequestIdParameters(correlationId, replyToId, deviceId, MessagingType.pubsub);
+        assertThat(requestId).isNotNull();
+        assertThat(requestId.contains(correlationId)).isTrue();
+        assertThat(requestId.contains(replyToId)).isTrue();
+
+        // do the reverse operation
+        final CommandRequestIdParameters requestIdParams = Commands.decodeRequestIdParameters(requestId, deviceId);
+        assertThat(requestIdParams.getCorrelationId()).isEqualTo(correlationId);
+        assertThat(requestIdParams.getReplyToId()).isEqualTo(replyToId);
+        assertThat(requestIdParams.getMessagingType()).isEqualTo(MessagingType.pubsub);
+    }
+
+    /**
      * Verifies that getting the request id with a replyToId starting with the deviceId returns the expected value.
      */
     @Test
@@ -136,6 +156,23 @@ public class CommandsTest {
                 .getOriginalReplyToIdAndMessagingType(deviceFacingReplyToId, deviceId);
         assertThat(originalReplyToIdMessagingTypePair.one()).isEqualTo(replyToId);
         assertThat(originalReplyToIdMessagingTypePair.two()).isEqualTo(MessagingType.amqp);
+    }
+
+    /**
+     * Verifies that getting the device-facing-reply-id with messaging type set to Pub/Sub returns the expected result.
+     */
+    @Test
+    public void testGetDeviceFacingReplyToIdWithMessagingTypePubSub() {
+        final String replyToId = "replyToId";
+        final String deviceId = "deviceId";
+        final String deviceFacingReplyToId = Commands.getDeviceFacingReplyToId(replyToId, deviceId, MessagingType.pubsub);
+        assertThat(deviceFacingReplyToId).contains(deviceId);
+
+        // do the reverse operation
+        final Pair<String, MessagingType> originalReplyToIdMessagingTypePair = Commands
+                .getOriginalReplyToIdAndMessagingType(deviceFacingReplyToId, deviceId);
+        assertThat(originalReplyToIdMessagingTypePair.one()).isEqualTo(replyToId);
+        assertThat(originalReplyToIdMessagingTypePair.two()).isEqualTo(MessagingType.pubsub);
     }
 
     /**

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -37,6 +37,7 @@
     <module>command</module>
     <module>command-amqp</module>
     <module>command-kafka</module>
+    <module>command-pubsub</module>
     <module>device-amqp</module>
     <module>kafka-common</module>
     <module>notification</module>

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubBasedAdminClientManager.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubBasedAdminClientManager.java
@@ -274,7 +274,7 @@ public class PubSubBasedAdminClientManager {
         if (subscriptionAdminClient != null) {
             subscriptionAdminClient.shutdown();
             try {
-                subscriptionAdminClient.awaitTermination(1, TimeUnit.MINUTES);
+                subscriptionAdminClient.awaitTermination(5, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 LOG.debug("Resources are not freed properly, error", e);
                 Thread.currentThread().interrupt();
@@ -286,7 +286,7 @@ public class PubSubBasedAdminClientManager {
         if (topicAdminClient != null) {
             topicAdminClient.shutdown();
             try {
-                topicAdminClient.awaitTermination(1, TimeUnit.MINUTES);
+                topicAdminClient.awaitTermination(5, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 LOG.debug("Resources are not freed properly, error", e);
                 Thread.currentThread().interrupt();

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubBasedAdminClientManager.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubBasedAdminClientManager.java
@@ -1,0 +1,296 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.hono.client.pubsub;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient.ListSubscriptionsPagedResponse;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient.ListTopicsPagedResponse;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
+import com.google.protobuf.util.Durations;
+import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.SubscriptionName;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+/**
+ * A Pub/Sub based admin client manager to manage topics and subscriptions. Wraps a TopicAdminClient and a
+ * SubscriptionAdminClient.
+ */
+public class PubSubBasedAdminClientManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PubSubBasedAdminClientManager.class);
+
+    /**
+     * The message retention in milliseconds for a Pub/Sub subscription.
+     */
+    private static final long MESSAGE_RETENTION = 600000;
+    private final Supplier<Future<SubscriptionAdminClient>> subscriptionAdminClientCreator;
+    private final Supplier<Future<TopicAdminClient>> topicAdminClientCreator;
+    private final String projectId;
+
+    /**
+     * A set of existing subscriptions. It contains subscriptions with the format
+     * `"projects/{project}/subscriptions/{subscription}"`.
+     */
+    private final Set<String> subscriptions = new HashSet<>();
+    /**
+     * A set of existing topics. It contains topics with the format `"projects/{project}/topics/{topic}"`.
+     */
+    private final Set<String> topics = new HashSet<>();
+    private final CredentialsProvider credentialsProvider;
+    private final Context context;
+    private SubscriptionAdminClient subscriptionAdminClient;
+    private TopicAdminClient topicAdminClient;
+
+    /**
+     * Creates a new PubSubBasedAdminClientManager.
+     *
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param credentialsProvider The provider for credentials to use for authenticating to the Pub/Sub service.
+     * @param vertx The Vert.x instance to use.
+     */
+    public PubSubBasedAdminClientManager(final String projectId, final CredentialsProvider credentialsProvider, final Vertx vertx) {
+        this.projectId = Objects.requireNonNull(projectId);
+        this.credentialsProvider = Objects.requireNonNull(credentialsProvider);
+        subscriptionAdminClientCreator = this::createSubscriptionAdminClient;
+        topicAdminClientCreator = this::createTopicAdminClient;
+        context = vertx.getOrCreateContext();
+    }
+
+    private Future<SubscriptionAdminClient> createSubscriptionAdminClient() {
+        try {
+            final SubscriptionAdminSettings adminSettings = SubscriptionAdminSettings
+                    .newBuilder()
+                    .setCredentialsProvider(credentialsProvider)
+                    .build();
+            final SubscriptionAdminClient adminClient = SubscriptionAdminClient.create(adminSettings);
+            return Future.succeededFuture(adminClient);
+        } catch (IOException e) {
+            LOG.debug("Error initializing subscription admin client: {}", e.getMessage());
+            return Future.failedFuture("Error creating client");
+        }
+    }
+
+    private Future<TopicAdminClient> createTopicAdminClient() {
+        try {
+            final TopicAdminSettings adminSettings = TopicAdminSettings
+                    .newBuilder()
+                    .setCredentialsProvider(credentialsProvider)
+                    .build();
+            final TopicAdminClient adminClient = TopicAdminClient.create(adminSettings);
+            return Future.succeededFuture(adminClient);
+        } catch (IOException e) {
+            LOG.debug("Error initializing topic admin client: {}", e.getMessage());
+            return Future.failedFuture("Error creating client");
+        }
+    }
+
+    /**
+     * Gets an existing or creates a new Topic and Subscription on Pub/Sub based on the given topic endpoint and prefix.
+     *
+     * @param endpoint The endpoint name of the topic and the subscription, e.g. command_internal.
+     * @param prefix The prefix of the topic and the subscription, e.g. the adapter instance ID.
+     * @return A succeeded Future if topic and subscription are successfully created or already exists, or a failed
+     *         Future if the topic or the subscription could not be created.
+     */
+    public Future<String> getOrCreateTopicAndSubscription(final String endpoint, final String prefix) {
+        final String topicAndSubscriptionName = PubSubMessageHelper.getTopicName(endpoint, prefix);
+        final TopicName topic = TopicName.of(projectId, topicAndSubscriptionName);
+        final SubscriptionName subscription = SubscriptionName.of(projectId, topicAndSubscriptionName);
+
+        return getOrCreateTopic(topic)
+                .onFailure(t -> LOG.warn("Error creating topic {}", topicAndSubscriptionName))
+                .recover(Future::failedFuture)
+                .compose(s -> getOrCreateSubscription(subscription, topic));
+    }
+
+    /**
+     * Closes the TopicAdminClient and the SubscriptionAdminClient if it exists. This method is expected to be invoked
+     * as soon as the TopicAdminClient and the SubscriptionAdminClient is no longer needed.
+     *
+     * @return A future that is completed when the close operation completed or a succeeded future if no
+     *         TopicAdminClient or SubscriptionAdminClient existed.
+     * @throws IllegalStateException if clients are not running on a Vert.x Context.
+     */
+    public Future<Void> closeAdminClients() {
+        if (topicAdminClient == null && subscriptionAdminClient == null) {
+            return Future.succeededFuture();
+        }
+        final Promise<Void> adminClientClosePromise = Promise.promise();
+        if (context == null) {
+            throw new IllegalStateException("Clients are not running on a Vert.x Context");
+        } else {
+            context.executeBlocking(future -> {
+                closeSubscriptionAdminClient();
+                closeTopicAdminClient();
+                future.complete();
+            }, adminClientClosePromise);
+            return adminClientClosePromise.future();
+        }
+    }
+
+    private Future<Void> getOrCreateTopic(final TopicName topic) {
+        return topicAdminClientCreator.get()
+                .onFailure(thr -> LOG.error("admin client creation failed", thr))
+                .recover(Future::failedFuture)
+                .compose(client -> {
+                    topicAdminClient = client;
+                    return getOrCreateTopic(projectId, topic);
+                });
+    }
+
+    private Future<Void> getOrCreateTopic(final String projectId, final TopicName topic) {
+        if (topicExists(topic.toString())) {
+            return Future.succeededFuture();
+        }
+        final Topic createdTopic = topicAdminClient.createTopic(topic);
+        if (createdTopic == null) {
+            LOG.debug("Creating topic failed [topic: {}, projectId: {}]", topic.toString(), projectId);
+            return Future.failedFuture("Topic creation failed.");
+        }
+        topics.add(topic.toString());
+        return Future.succeededFuture();
+    }
+
+    private boolean topicExists(final String topicId) {
+        if (topics.contains(topicId)) {
+            return true;
+        }
+        final ProjectName projectName = ProjectName.of(projectId);
+        try {
+            final ListTopicsPagedResponse pagedResponse = topicAdminClient.listTopics(projectName);
+            if (pagedResponse != null) {
+                for (Topic topic : pagedResponse.iterateAll()) {
+                    if (topic.getName().equals(topicId)) {
+                        topics.add(topicId);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (ApiException e) {
+            LOG.error("Error listing topics on project {}", projectId, e);
+            return false;
+        }
+
+    }
+
+    private Future<String> getOrCreateSubscription(final SubscriptionName subscription, final TopicName topic) {
+        return subscriptionAdminClientCreator.get()
+                .onFailure(thr -> LOG.error("admin client creation failed", thr))
+                .recover(Future::failedFuture)
+                .compose(client -> {
+                    subscriptionAdminClient = client;
+                    return getOrCreateSubscription(projectId, subscription, topic);
+                });
+    }
+
+    private Future<String> getOrCreateSubscription(
+            final String projectId,
+            final SubscriptionName subscription,
+            final TopicName topic) {
+
+        if (subscriptionExists(subscription.toString())) {
+            return Future.succeededFuture(subscription.getSubscription());
+        }
+        try {
+            final Subscription request = Subscription.newBuilder()
+                    .setName(subscription.toString())
+                    .setTopic(topic.toString())
+                    .setPushConfig(PushConfig.getDefaultInstance())
+                    .setAckDeadlineSeconds(0)
+                    .setMessageRetentionDuration(Durations.fromMillis(MESSAGE_RETENTION))
+                    .build();
+            final Subscription createdSubscription = subscriptionAdminClient.createSubscription(request);
+            if (createdSubscription == null) {
+                LOG.error("Creating subscription failed [subscription: {}, topic: {}, project: {}]", subscription,
+                        topic,
+                        projectId);
+                return Future.failedFuture("Subscription creation failed.");
+            }
+            subscriptions.add(createdSubscription.getName());
+            return Future.succeededFuture(subscription.getSubscription());
+        } catch (ApiException e) {
+            LOG.error("Error creating subscription {} for topic {} on project {}", subscription, topic,
+                    projectId, e);
+            return Future.failedFuture("Subscription creation failed.");
+        }
+    }
+
+    private boolean subscriptionExists(final String subscriptionName) {
+        if (subscriptions.contains(subscriptionName)) {
+            return true;
+        }
+        final ProjectName projectName = ProjectName.of(projectId);
+        try {
+            final ListSubscriptionsPagedResponse pagedResponse = subscriptionAdminClient.listSubscriptions(projectName);
+            if (pagedResponse != null) {
+                for (Subscription subscription : pagedResponse.iterateAll()) {
+                    if (subscription.getName().equals(subscriptionName)) {
+                        subscriptions.add(subscriptionName);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            LOG.error("Error listing subscriptions on project {}", projectId, e);
+            return false;
+        }
+    }
+
+    private void closeSubscriptionAdminClient() {
+        if (subscriptionAdminClient != null) {
+            subscriptionAdminClient.shutdown();
+            try {
+                subscriptionAdminClient.awaitTermination(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                LOG.debug("Resources are not freed properly, error", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void closeTopicAdminClient() {
+        if (topicAdminClient != null) {
+            topicAdminClient.shutdown();
+            try {
+                topicAdminClient.awaitTermination(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                LOG.debug("Resources are not freed properly, error", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
@@ -13,8 +13,12 @@
 package org.eclipse.hono.client.pubsub;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.util.MessageHelper;
 
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.FixedCredentialsProvider;
@@ -26,6 +30,31 @@ import com.google.pubsub.v1.PubsubMessage;
  * Utility methods for working with Pub/Sub.
  */
 public final class PubSubMessageHelper {
+
+    /**
+     * The name of the Pub/Sub message property containing the identifier of the Google Cloud Project to connect to.
+     */
+    public static final String PUBSUB_PROPERTY_PROJECT_ID = "projectId";
+    /**
+     * The name of Pub/Sub message property containing the ID of the tenant the device belongs to.
+     */
+    public static final String PUBSUB_PROPERTY_TENANT_ID = "tenant_id";
+    /**
+     * The name of the Pub/Sub message property containing the ID of the device.
+     */
+    public static final String PUBSUB_PROPERTY_DEVICE_ID = "device_id";
+    /**
+     * The name of the Pub/Sub message property containing the ID of the device registry the device belongs to.
+     */
+    public static final String PUBSUB_PROPERTY_DEVICE_REGISTRY_ID = "deviceRegistryId";
+
+    public static final String PUBSUB_PROPERTY_RESPONSE_REQUIRED = "response-required";
+
+    /**
+     * Prefix to use in the Pub/Sub message properties for marking properties of command messages that should be included
+     * in response messages indicating failure to deliver the command.
+     */
+    public static final String DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX = "delivery-failure-notification-metadata";
 
     private PubSubMessageHelper() {
     }
@@ -73,4 +102,98 @@ public final class PubSubMessageHelper {
         Objects.requireNonNull(message);
         return message.getData().toByteArray();
     }
+    /**
+     * Gets the value of the {@value PUBSUB_PROPERTY_DEVICE_ID} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static Optional<String> getDeviceId(final Map<String, String> attributesMap) {
+        return getAttributesValue(attributesMap, PUBSUB_PROPERTY_DEVICE_ID);
+    }
+
+    /**
+     * Gets the value of the {@value PUBSUB_PROPERTY_DEVICE_REGISTRY_ID} attribute, or if its not present, get the value
+     * of the {@value PUBSUB_PROPERTY_TENANT_ID} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static Optional<String> getTenantId(final Map<String, String> attributesMap) {
+        return getAttributesValue(attributesMap, PUBSUB_PROPERTY_DEVICE_REGISTRY_ID)
+                .or(() -> getAttributesValue(attributesMap, PUBSUB_PROPERTY_TENANT_ID));
+    }
+
+    /**
+     * Gets the value of the {@value MessageHelper#SYS_PROPERTY_CORRELATION_ID} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static Optional<String> getCorrelationId(final Map<String, String> attributesMap) {
+        return getAttributesValue(attributesMap, MessageHelper.SYS_PROPERTY_CORRELATION_ID);
+    }
+
+    /**
+     * Gets the value of the {@value PUBSUB_PROPERTY_RESPONSE_REQUIRED} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static boolean isResponseRequired(final Map<String, String> attributesMap) {
+        return Boolean
+                .parseBoolean(getAttributesValue(attributesMap, PUBSUB_PROPERTY_RESPONSE_REQUIRED).orElse("false"));
+    }
+
+    /**
+     * Gets the value of the {@value MessageHelper#SYS_PROPERTY_CONTENT_TYPE} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static Optional<String> getContentType(final Map<String, String> attributesMap) {
+        return getAttributesValue(attributesMap, MessageHelper.SYS_PROPERTY_CONTENT_TYPE);
+    }
+
+    /**
+     * Gets the value of the {@value MessageHelper#SYS_PROPERTY_SUBJECT} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static Optional<String> getSubject(final Map<String, String> attributesMap) {
+        return getAttributesValue(attributesMap, MessageHelper.SYS_PROPERTY_SUBJECT);
+    }
+
+    /**
+     * Gets the properties of the attributes which starts with the prefix {@value DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX}.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The properties.
+     */
+    public static Map<String, String> getDeliveryFailureNotificationMetadata(final Map<String, String> attributesMap) {
+        Objects.requireNonNull(attributesMap);
+        return attributesMap
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().startsWith(DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    /**
+     * Gets the value of the {@value MessageHelper#APP_PROPERTY_CMD_VIA} attribute.
+     *
+     * @param attributesMap The attributes map to get the value from.
+     * @return The attributes value.
+     */
+    public static Optional<String> getVia(final Map<String, String> attributesMap) {
+        return getAttributesValue(attributesMap, MessageHelper.APP_PROPERTY_CMD_VIA);
+    }
+
+    private static Optional<String> getAttributesValue(final Map<String, String> attributesMap, final String key) {
+        Objects.requireNonNull(attributesMap);
+        Objects.requireNonNull(key);
+        return Optional.ofNullable(attributesMap.get(key));
+    }
+
 }

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
@@ -35,18 +35,6 @@ public final class PubSubMessageHelper {
      * The name of the Pub/Sub message property containing the identifier of the Google Cloud Project to connect to.
      */
     public static final String PUBSUB_PROPERTY_PROJECT_ID = "projectId";
-    /**
-     * The name of Pub/Sub message property containing the ID of the tenant the device belongs to.
-     */
-    public static final String PUBSUB_PROPERTY_TENANT_ID = "tenant_id";
-    /**
-     * The name of the Pub/Sub message property containing the ID of the device.
-     */
-    public static final String PUBSUB_PROPERTY_DEVICE_ID = "device_id";
-    /**
-     * The name of the Pub/Sub message property containing the ID of the device registry the device belongs to.
-     */
-    public static final String PUBSUB_PROPERTY_DEVICE_REGISTRY_ID = "deviceRegistryId";
 
     public static final String PUBSUB_PROPERTY_RESPONSE_REQUIRED = "response-required";
 
@@ -103,25 +91,23 @@ public final class PubSubMessageHelper {
         return message.getData().toByteArray();
     }
     /**
-     * Gets the value of the {@value PUBSUB_PROPERTY_DEVICE_ID} attribute.
+     * Gets the value of the {@link MessageHelper#APP_PROPERTY_DEVICE_ID} attribute.
      *
      * @param attributesMap The attributes map to get the value from.
      * @return The attributes value.
      */
     public static Optional<String> getDeviceId(final Map<String, String> attributesMap) {
-        return getAttributesValue(attributesMap, PUBSUB_PROPERTY_DEVICE_ID);
+        return getAttributesValue(attributesMap, MessageHelper.APP_PROPERTY_DEVICE_ID);
     }
 
     /**
-     * Gets the value of the {@value PUBSUB_PROPERTY_DEVICE_REGISTRY_ID} attribute, or if its not present, get the value
-     * of the {@value PUBSUB_PROPERTY_TENANT_ID} attribute.
+     * Gets the value of the {@link MessageHelper#APP_PROPERTY_TENANT_ID} attribute.
      *
      * @param attributesMap The attributes map to get the value from.
      * @return The attributes value.
      */
     public static Optional<String> getTenantId(final Map<String, String> attributesMap) {
-        return getAttributesValue(attributesMap, PUBSUB_PROPERTY_DEVICE_REGISTRY_ID)
-                .or(() -> getAttributesValue(attributesMap, PUBSUB_PROPERTY_TENANT_ID));
+        return getAttributesValue(attributesMap, MessageHelper.APP_PROPERTY_TENANT_ID);
     }
 
     /**

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubMessageExtractAdapter.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubMessageExtractAdapter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.tracing;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.propagation.TextMap;
+
+/**
+ * An adapter for extracting properties from a list of {@link com.google.pubsub.v1.PubsubMessage} objects.
+ *
+ */
+public class PubSubMessageExtractAdapter implements TextMap {
+
+    private final PubsubMessage message;
+
+    /**
+     * Creates an adapter for a Pub/Sub message.
+     *
+     * @param message The Pub/Sub message.
+     */
+    public PubSubMessageExtractAdapter(final PubsubMessage message) {
+        this.message = Objects.requireNonNull(message);
+    }
+
+    @Override
+    public Iterator<Entry<String, String>> iterator() {
+        if (message.getAttributesMap().isEmpty()) {
+            return Collections.emptyIterator();
+        }
+        final Iterator<Entry<String, String>> entriesIterator = message.getAttributesMap().entrySet().iterator();
+        return new Iterator<>() {
+
+            @Override
+            public boolean hasNext() {
+                return entriesIterator.hasNext();
+            }
+
+            @Override
+            public Entry<String, String> next() {
+                final Entry<String, String> nextEntry = entriesIterator.next();
+                return new SimpleEntry<>(nextEntry.getKey(), nextEntry.getValue());
+            }
+        };
+    }
+
+    @Override
+    public void put(final String s, final String s1) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubMessageExtractAdapter.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubMessageExtractAdapter.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.hono.client.pubsub.tracing;
 
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -40,9 +39,6 @@ public class PubSubMessageExtractAdapter implements TextMap {
 
     @Override
     public Iterator<Entry<String, String>> iterator() {
-        if (message.getAttributesMap().isEmpty()) {
-            return Collections.emptyIterator();
-        }
         return message.getAttributesMap().entrySet().iterator();
     }
 

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubMessageExtractAdapter.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubMessageExtractAdapter.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.hono.client.pubsub.tracing;
 
-import java.util.AbstractMap.SimpleEntry;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -44,20 +43,7 @@ public class PubSubMessageExtractAdapter implements TextMap {
         if (message.getAttributesMap().isEmpty()) {
             return Collections.emptyIterator();
         }
-        final Iterator<Entry<String, String>> entriesIterator = message.getAttributesMap().entrySet().iterator();
-        return new Iterator<>() {
-
-            @Override
-            public boolean hasNext() {
-                return entriesIterator.hasNext();
-            }
-
-            @Override
-            public Entry<String, String> next() {
-                final Entry<String, String> nextEntry = entriesIterator.next();
-                return new SimpleEntry<>(nextEntry.getKey(), nextEntry.getValue());
-            }
-        };
+        return message.getAttributesMap().entrySet().iterator();
     }
 
     @Override

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubTracingHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/tracing/PubSubTracingHelper.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.client.pubsub.tracing;
+
+import java.util.Objects;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+/**
+ * A helper class providing Pub/Sub-specific utility methods for interacting with the OpenTracing API.
+ *
+ */
+public final class PubSubTracingHelper {
+
+    private PubSubTracingHelper() {
+        // prevent instantiation
+    }
+
+    /**
+     * Extracts a {@code SpanContext} from a Pub/Sub message.
+     * <p>
+     * The span context will be read from the Pub/Sub message attributes.
+     *
+     * @param tracer The Tracer to use for extracting the context.
+     * @param message The Pub/Sub message to extract the context from.
+     * @return The context or {@code null} if the given Pub/Sub message does not contain a context.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public static SpanContext extractSpanContext(final Tracer tracer, final PubsubMessage message) {
+
+        Objects.requireNonNull(tracer);
+        Objects.requireNonNull(message);
+
+        return tracer.extract(Format.Builtin.TEXT_MAP, new PubSubMessageExtractAdapter(message));
+    }
+}

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
@@ -16,8 +16,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 
+import org.eclipse.hono.util.MessageHelper;
 import org.junit.jupiter.api.Test;
 
 import com.google.protobuf.ByteString;
@@ -74,5 +78,139 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatGetPayloadThrowsNullPointer() {
         assertThrows(NullPointerException.class, () -> PubSubMessageHelper.getPayload(null));
+    }
+    /**
+     * Verifies that the getDeviceId method returns an Optional describing the device ID.
+     */
+    @Test
+    public void testThatGetDeviceIdReturnsDeviceId() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, "test-tenant");
+
+        final Optional<String> result = PubSubMessageHelper.getDeviceId(attributesMap);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo("test-device");
+    }
+
+    /**
+     * Verifies that the getTenantId method returns an empty Optional.
+     */
+    @Test
+    public void testThatGetTenantIdReturnsEmptyOptional() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_GATEWAY_ID, "test-gateway");
+
+        final Optional<String> result = PubSubMessageHelper.getTenantId(attributesMap);
+        assertThat(result.isPresent()).isFalse();
+    }
+
+    /**
+     * Verifies that the getCorrelationId method returns an Optional describing the correlation ID.
+     */
+    @Test
+    public void testThatGetCorrelationIdReturnsCorrelationId() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, "test-tenant",
+                MessageHelper.SYS_PROPERTY_CORRELATION_ID, "correlation-id-test");
+
+        final Optional<String> result = PubSubMessageHelper.getCorrelationId(attributesMap);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo("correlation-id-test");
+    }
+
+    /**
+     * Verifies that the isResponseRequired method returns true.
+     */
+    @Test
+    public void testThatIsResponseRequiredReturnsTrue() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, "true");
+
+        final boolean result = PubSubMessageHelper.isResponseRequired(attributesMap);
+        assertThat(result).isTrue();
+    }
+
+    /**
+     * Verifies that the isResponseRequired method returns false when property is not set.
+     */
+    @Test
+    public void testThatIsResponseRequiredReturnsFalse() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, "test-tenant");
+
+        final boolean result = PubSubMessageHelper.isResponseRequired(attributesMap);
+        assertThat(result).isFalse();
+    }
+
+    /**
+     * Verifies that the getContentType method returns an empty Optional.
+     */
+    @Test
+    public void testThatGetContentTypeReturnsEmptyContentType() {
+        final Map<String, String> attributesMap = new HashMap<>();
+
+        final Optional<String> result = PubSubMessageHelper.getContentType(attributesMap);
+        assertThat(result.isPresent()).isFalse();
+    }
+
+    /**
+     * Verifies that the getSubject method returns an Optional describing the subject.
+     */
+    @Test
+    public void testThatGetSubjectReturnsSubject() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.SYS_PROPERTY_SUBJECT, "test-command");
+
+        final Optional<String> result = PubSubMessageHelper.getSubject(attributesMap);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo("test-command");
+    }
+
+    /**
+     * Verifies the return value of getDeliveryFailureNotificationMetadata.
+     */
+    @Test
+    public void testThatGetDeliveryFailureNotificationMetadataReturnsProperties() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX, "test",
+                PubSubMessageHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX + "-test", "isPresent");
+        attributesMap.put("another-key", "another-value");
+
+        final Map<String, String> deliveryFailureNotificationProperties = PubSubMessageHelper.getDeliveryFailureNotificationMetadata(attributesMap);
+
+        assertThat(deliveryFailureNotificationProperties.size()).isEqualTo(2);
+
+        assertThat(deliveryFailureNotificationProperties.get(PubSubMessageHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX))
+                .isEqualTo("test");
+
+        assertThat(deliveryFailureNotificationProperties.get(PubSubMessageHelper.DELIVERY_FAILURE_NOTIFICATION_METADATA_PREFIX + "-test"))
+                .isEqualTo("isPresent");
+    }
+
+    /**
+     * Verifies that the getVia method returns an Optional describing the VIA property.
+     */
+    @Test
+    public void testThatGetViaReturnsViaProperty() {
+        final Map<String, String> attributesMap = getAttributes(
+                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_CMD_VIA, "test-gateway");
+
+        final Optional<String> result = PubSubMessageHelper.getVia(attributesMap);
+        assertThat(result.isPresent()).isTrue();
+        assertThat(result.get()).isEqualTo("test-gateway");
+    }
+
+    private Map<String, String> getAttributes(final String property1, final String value1, final String property2,
+            final String value2) {
+        final Map<String, String> attributesMap = new HashMap<>();
+        attributesMap.put(property1, value1);
+        attributesMap.put(property2, value2);
+        return attributesMap;
     }
 }

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
@@ -85,8 +85,8 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatGetDeviceIdReturnsDeviceId() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
-                PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, "test-tenant");
+                MessageHelper.APP_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_TENANT_ID, "test-tenant");
 
         final Optional<String> result = PubSubMessageHelper.getDeviceId(attributesMap);
         assertThat(result.isPresent()).isTrue();
@@ -99,7 +99,7 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatGetTenantIdReturnsEmptyOptional() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_DEVICE_ID, "test-device",
                 MessageHelper.APP_PROPERTY_GATEWAY_ID, "test-gateway");
 
         final Optional<String> result = PubSubMessageHelper.getTenantId(attributesMap);
@@ -112,7 +112,7 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatGetCorrelationIdReturnsCorrelationId() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, "test-tenant",
+                MessageHelper.APP_PROPERTY_TENANT_ID, "test-tenant",
                 MessageHelper.SYS_PROPERTY_CORRELATION_ID, "correlation-id-test");
 
         final Optional<String> result = PubSubMessageHelper.getCorrelationId(attributesMap);
@@ -126,7 +126,7 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatIsResponseRequiredReturnsTrue() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_DEVICE_ID, "test-device",
                 PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, "true");
 
         final boolean result = PubSubMessageHelper.isResponseRequired(attributesMap);
@@ -139,8 +139,8 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatIsResponseRequiredReturnsFalse() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
-                PubSubMessageHelper.PUBSUB_PROPERTY_TENANT_ID, "test-tenant");
+                MessageHelper.APP_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_TENANT_ID, "test-tenant");
 
         final boolean result = PubSubMessageHelper.isResponseRequired(attributesMap);
         assertThat(result).isFalse();
@@ -163,7 +163,7 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatGetSubjectReturnsSubject() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_DEVICE_ID, "test-device",
                 MessageHelper.SYS_PROPERTY_SUBJECT, "test-command");
 
         final Optional<String> result = PubSubMessageHelper.getSubject(attributesMap);
@@ -198,7 +198,7 @@ public class PubSubMessageHelperTest {
     @Test
     public void testThatGetViaReturnsViaProperty() {
         final Map<String, String> attributesMap = getAttributes(
-                PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_ID, "test-device",
+                MessageHelper.APP_PROPERTY_DEVICE_ID, "test-device",
                 MessageHelper.APP_PROPERTY_CMD_VIA, "test-gateway");
 
         final Optional<String> result = PubSubMessageHelper.getVia(attributesMap);

--- a/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
+++ b/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
@@ -48,14 +48,19 @@ public final class PubSubBasedDownstreamSender extends AbstractPubSubBasedMessag
         implements TelemetrySender, EventSender {
 
     /**
-     * The name of Pub/Sub message property containing the ID of the tenant the device belongs to.
+     * The name of Pub/Sub downstream message property containing the ID of the tenant the device belongs to.
      */
     private static final String PUBSUB_DOWNSTREAM_PROPERTY_TENANT_ID = "tenantId";
 
     /**
-     * The name of the Pub/Sub message property containing the ID of the device.
+     * The name of the Pub/Sub downstream message property containing the ID of the device.
      */
     private static final String PUBSUB_DOWNSTREAM_PROPERTY_DEVICE_ID = "deviceId";
+
+    /**
+     * The name of the Pub/Sub downstream message property containing the ID of the device registry the device belongs to.
+     */
+    private static final String PUBSUB_DOWNSTREAM_PROPERTY_DEVICE_REGISTRY_ID = "deviceRegistryId";
 
     private final boolean isDefaultsEnabled;
 
@@ -195,7 +200,7 @@ public final class PubSubBasedDownstreamSender extends AbstractPubSubBasedMessag
         messageProperties.put(PUBSUB_DOWNSTREAM_PROPERTY_DEVICE_ID, device.getDeviceId());
         messageProperties.put(MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
         messageProperties.put(PUBSUB_DOWNSTREAM_PROPERTY_TENANT_ID, tenant.getTenantId());
-        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, tenant.getTenantId());
+        messageProperties.put(PUBSUB_DOWNSTREAM_PROPERTY_DEVICE_REGISTRY_ID, tenant.getTenantId());
         messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
 
         Optional.ofNullable(contentType)

--- a/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
+++ b/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
@@ -48,21 +48,14 @@ public final class PubSubBasedDownstreamSender extends AbstractPubSubBasedMessag
         implements TelemetrySender, EventSender {
 
     /**
-     * The name of the Pub/Sub message property containing the ID of the GCP project Pub/Sub belongs to.
-     */
-    private static final String PUBSUB_PROPERTY_PROJECT_ID = "projectId";
-    /**
      * The name of Pub/Sub message property containing the ID of the tenant the device belongs to.
      */
-    private static final String PUBSUB_PROPERTY_TENANT_ID = "tenantId";
+    private static final String PUBSUB_DOWNSTREAM_PROPERTY_TENANT_ID = "tenantId";
+
     /**
      * The name of the Pub/Sub message property containing the ID of the device.
      */
-    private static final String PUBSUB_PROPERTY_DEVICE_ID = "deviceId";
-    /**
-     * The name of the Pub/Sub message property containing the ID of the device registry the device belongs to.
-     */
-    private static final String PUBSUB_PROPERTY_DEVICE_REGISTRY_ID = "deviceRegistryId";
+    private static final String PUBSUB_DOWNSTREAM_PROPERTY_DEVICE_ID = "deviceId";
 
     private final boolean isDefaultsEnabled;
 
@@ -199,11 +192,11 @@ public final class PubSubBasedDownstreamSender extends AbstractPubSubBasedMessag
                 .map(HashMap::new)
                 .orElseGet(HashMap::new);
 
-        messageProperties.put(PUBSUB_PROPERTY_DEVICE_ID, device.getDeviceId());
+        messageProperties.put(PUBSUB_DOWNSTREAM_PROPERTY_DEVICE_ID, device.getDeviceId());
         messageProperties.put(MessageHelper.APP_PROPERTY_QOS, qos.ordinal());
-        messageProperties.put(PUBSUB_PROPERTY_TENANT_ID, tenant.getTenantId());
-        messageProperties.put(PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, tenant.getTenantId());
-        messageProperties.put(PUBSUB_PROPERTY_PROJECT_ID, projectId);
+        messageProperties.put(PUBSUB_DOWNSTREAM_PROPERTY_TENANT_ID, tenant.getTenantId());
+        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_DEVICE_REGISTRY_ID, tenant.getTenantId());
+        messageProperties.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
 
         Optional.ofNullable(contentType)
                 .ifPresent(ct -> messageProperties.put(MessageHelper.SYS_PROPERTY_CONTENT_TYPE, ct));

--- a/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
+++ b/core/src/main/java/org/eclipse/hono/util/CommandConstants.java
@@ -98,6 +98,11 @@ public class CommandConstants {
     public static final String MSG_PROPERTY_DEVICE_TTD = "ttd";
 
     /**
+     * The operation name of the span used by the internal command sender.
+     */
+    public static final String INTERNAL_COMMAND_SPAN_OPERATION_NAME = "delegate Command request";
+
+    /**
      * Position of the status code in the MQTT command response topic.
      * {@code command/[tenant]/[device-id]/res/<req-id>/<status>}
      */

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Objects;
 
 import org.apache.kafka.common.TopicPartition;
+import org.eclipse.hono.client.command.kafka.KafkaBasedCommand;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandContext;
 import org.eclipse.hono.commandrouter.impl.AbstractCommandProcessingQueue;
 
@@ -52,8 +53,12 @@ public class KafkaCommandProcessingQueue extends AbstractCommandProcessingQueue<
 
     @Override
     protected TopicPartition getQueueKey(final KafkaBasedCommandContext commandContext) {
-        final KafkaConsumerRecord<String, Buffer> record = commandContext.getCommand().getRecord();
-        return new TopicPartition(record.topic(), record.partition());
+        if (commandContext.getCommand() instanceof KafkaBasedCommand command) {
+            final KafkaConsumerRecord<String, Buffer> record = command.getRecord();
+            return new TopicPartition(record.topic(), record.partition());
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueue.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.Objects;
 
 import org.apache.kafka.common.TopicPartition;
-import org.eclipse.hono.client.command.kafka.KafkaBasedCommand;
 import org.eclipse.hono.client.command.kafka.KafkaBasedCommandContext;
 import org.eclipse.hono.commandrouter.impl.AbstractCommandProcessingQueue;
 
@@ -53,12 +52,8 @@ public class KafkaCommandProcessingQueue extends AbstractCommandProcessingQueue<
 
     @Override
     protected TopicPartition getQueueKey(final KafkaBasedCommandContext commandContext) {
-        if (commandContext.getCommand() instanceof KafkaBasedCommand command) {
-            final KafkaConsumerRecord<String, Buffer> record = command.getRecord();
-            return new TopicPartition(record.topic(), record.partition());
-        } else {
-            return null;
-        }
+        final KafkaConsumerRecord<String, Buffer> record = commandContext.getCommand().getRecord();
+        return new TopicPartition(record.topic(), record.partition());
     }
 
     @Override


### PR DESCRIPTION
This is another PR to use Pub/Sub as only messaging infrastructure. As part of this architecture we added a Pub/Sub based implementation of the client for Hono's Command & Control API.

- Added new module to support a Pub/Sub based Command & Control implementation.
- Added constants for duplicate values on Kafka, AMQP and Pub/Sub implementations.
- Added Pub/Sub based admin client manager to manage topics and subscriptions.