### PR TITLE
[#3471] Add Pub/Sub based Command Router implementation

### DIFF
--- a/adapter-base/pom.xml
+++ b/adapter-base/pom.xml
@@ -53,6 +53,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-command-pubsub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-registry-amqp</artifactId>
     </dependency>
     <dependency>

--- a/services/command-router/pom.xml
+++ b/services/command-router/pom.xml
@@ -38,6 +38,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-command-pubsub</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-registry-amqp</artifactId>
     </dependency>
     <dependency>

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandConsumerFactoryImpl.java
@@ -121,9 +121,6 @@ public class PubSubBasedCommandConsumerFactoryImpl implements CommandConsumerFac
         } else if (!lifecycleStatus.setStarting()) {
             return Future.failedFuture(new IllegalStateException("factory is already started/stopping"));
         }
-        if (Vertx.currentContext() == null) {
-            return Future.failedFuture(new IllegalStateException("factory must be started in a Vert.x context"));
-        }
 
         final var commandQueue = new PubSubBasedCommandProcessingQueue(vertx);
         commandHandler = new PubSubBasedMappingAndDelegatingCommandHandler(
@@ -194,7 +191,7 @@ public class PubSubBasedCommandConsumerFactoryImpl implements CommandConsumerFac
     private void registerTenantCreationListener() {
         NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
                 notification -> {
-                    if (lifecycleStatus.isStarted() && LifecycleChange.CREATE == notification.getChange()
+                    if (lifecycleStatus.isStarted() && notification.getChange() == LifecycleChange.CREATE
                             && notification.isTenantEnabled()) {
                         // Optional optimization:
                         // Prepare Pub/Sub consumer to receive commands for devices of a newly created tenant by creating

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandConsumerFactoryImpl.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.commandrouter.impl.pubsub;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommandResponseSender;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedInternalCommandSender;
+import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
+import org.eclipse.hono.client.pubsub.publisher.PubSubPublisherFactory;
+import org.eclipse.hono.client.pubsub.subscriber.PubSubSubscriberFactory;
+import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.client.util.ServiceClient;
+import org.eclipse.hono.commandrouter.CommandConsumerFactory;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
+import org.eclipse.hono.notification.NotificationEventBusSupport;
+import org.eclipse.hono.notification.deviceregistry.LifecycleChange;
+import org.eclipse.hono.notification.deviceregistry.TenantChangeNotification;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.CommandConstants;
+import org.eclipse.hono.util.LifecycleStatus;
+import org.eclipse.hono.util.MessagingType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+
+/**
+ * A factory for creating clients for the <em>Pub/Sub messaging infrastructure</em> to receive commands.
+ * <p>
+ * Command messages are first received by the Pub/Sub subscriber on the tenant-specific topic. It is then determined
+ * which protocol adapter instance can handle the command. The command is then forwarded to Pub/Sub on a topic
+ * containing that adapter instance id.
+ */
+public class PubSubBasedCommandConsumerFactoryImpl implements CommandConsumerFactory, ServiceClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PubSubBasedCommandConsumerFactoryImpl.class);
+
+    private final Vertx vertx;
+    private final TenantClient tenantClient;
+    private final Tracer tracer;
+    private final PubSubBasedInternalCommandSender internalCommandSender;
+    private final PubSubBasedCommandResponseSender responseSender;
+    private final LifecycleStatus lifecycleStatus = new LifecycleStatus();
+    private final CommandTargetMapper commandTargetMapper;
+    private final CommandRouterMetrics metrics;
+    private final PubSubSubscriberFactory subscriberFactory;
+    private final Set<String> tenantIds = new HashSet<>();
+    private final Map<String, MessageReceiver> activeReceivers = new ConcurrentHashMap<>();
+    private PubSubBasedMappingAndDelegatingCommandHandler commandHandler;
+
+    /**
+     * Creates a new factory to process commands via Google Pub/Sub.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param tenantClient The Tenant service client.
+     * @param tracer The tracer instance.
+     * @param pubSubPublisherFactory The publisher factory for creating Pub/Sub publishers for sending messages.
+     * @param projectId The identifier of the Google Cloud Project to connect to.
+     * @param commandTargetMapper The component for mapping an incoming command to the gateway (if applicable) and
+     *            protocol adapter instance that can handle it. Note that no initialization of this factory will be done
+     *            here, that is supposed to be done by the calling method.
+     * @param metrics The component to use for reporting metrics.
+     * @param subscriberFactory The subscriber factory for creating Pub/Sub subscribers for receiving messages.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public PubSubBasedCommandConsumerFactoryImpl(
+            final Vertx vertx,
+            final TenantClient tenantClient,
+            final Tracer tracer,
+            final PubSubPublisherFactory pubSubPublisherFactory,
+            final String projectId,
+            final CommandTargetMapper commandTargetMapper,
+            final CommandRouterMetrics metrics,
+            final PubSubSubscriberFactory subscriberFactory) {
+        this.vertx = Objects.requireNonNull(vertx);
+        this.tenantClient = Objects.requireNonNull(tenantClient);
+        this.tracer = Objects.requireNonNull(tracer);
+        this.commandTargetMapper = Objects.requireNonNull(commandTargetMapper);
+        this.metrics = Objects.requireNonNull(metrics);
+        this.subscriberFactory = Objects.requireNonNull(subscriberFactory);
+        Objects.requireNonNull(pubSubPublisherFactory);
+        Objects.requireNonNull(projectId);
+
+        this.internalCommandSender = new PubSubBasedInternalCommandSender(pubSubPublisherFactory, projectId, tracer);
+        this.responseSender = new PubSubBasedCommandResponseSender(vertx, pubSubPublisherFactory, projectId, tracer);
+    }
+
+    @Override
+    public Future<Void> start() {
+        if (lifecycleStatus.isStarting()) {
+            return Future.succeededFuture();
+        } else if (!lifecycleStatus.setStarting()) {
+            return Future.failedFuture(new IllegalStateException("factory is already started/stopping"));
+        }
+        if (Vertx.currentContext() == null) {
+            return Future.failedFuture(new IllegalStateException("factory must be started in a Vert.x context"));
+        }
+
+        final var commandQueue = new PubSubBasedCommandProcessingQueue(vertx);
+        commandHandler = new PubSubBasedMappingAndDelegatingCommandHandler(
+                vertx,
+                tenantClient,
+                commandQueue,
+                commandTargetMapper,
+                internalCommandSender,
+                metrics,
+                tracer,
+                responseSender);
+
+        registerTenantCreationListener();
+        return commandHandler.start().onSuccess(s -> lifecycleStatus.setStarted());
+    }
+
+    @Override
+    public Future<Void> stop() {
+        return lifecycleStatus.runStopAttempt(
+                () -> CompositeFuture.join(subscriberFactory.closeAllSubscribers(), commandHandler.stop()).mapEmpty());
+    }
+
+    @Override
+    public MessagingType getMessagingType() {
+        return MessagingType.pubsub;
+    }
+
+    @Override
+    public Future<Void> createCommandConsumer(final String tenantId, final SpanContext context) {
+        if (tenantIds.contains(tenantId)) {
+            LOG.debug("Command consumer for tenant {} is already registered", tenantId);
+            return Future.succeededFuture();
+        }
+        tenantIds.add(tenantId);
+
+        final Span span = TracingHelper.buildServerChildSpan(
+                tracer,
+                context,
+                "create command consumer",
+                CommandConsumerFactory.class.getSimpleName())
+                .start();
+        TracingHelper.TAG_TENANT_ID.set(span, tenantId);
+        Tags.MESSAGE_BUS_DESTINATION.set(span, CommandConstants.COMMAND_ENDPOINT);
+
+        final MessageReceiver messageReceiver = getOrCreateReceiver(tenantId);
+
+        final String subscriptionId = PubSubMessageHelper.getTopicName(CommandConstants.COMMAND_ENDPOINT, tenantId);
+        return subscriberFactory
+                .getOrCreateSubscriber(subscriptionId, messageReceiver)
+                .subscribe(false);
+    }
+
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        internalCommandSender.registerReadinessChecks(readinessHandler);
+        responseSender.registerReadinessChecks(readinessHandler);
+        readinessHandler.register(
+                "command-consumer-factory-pubsub-subscriber-%s".formatted(UUID.randomUUID()),
+                status -> status.tryComplete(Status.OK()));
+    }
+
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        internalCommandSender.registerLivenessChecks(livenessHandler);
+        responseSender.registerLivenessChecks(livenessHandler);
+    }
+
+    private void registerTenantCreationListener() {
+        NotificationEventBusSupport.registerConsumer(vertx, TenantChangeNotification.TYPE,
+                notification -> {
+                    if (lifecycleStatus.isStarted() && LifecycleChange.CREATE == notification.getChange()
+                            && notification.isTenantEnabled()) {
+                        // Optional optimization:
+                        // Prepare Pub/Sub consumer to receive commands for devices of a newly created tenant by creating
+                        // the subscription. If not done here, this preparation is done in the "createCommandConsumer" method.
+                        // Doing it here will speed up the first invocation of "createCommandConsumer" for this tenant.
+                        final String tenantId = notification.getTenantId();
+                        final MessageReceiver messageReceiver = getOrCreateReceiver(tenantId);
+                        final String subscriptionId = PubSubMessageHelper.getTopicName(CommandConstants.COMMAND_ENDPOINT, tenantId);
+                        subscriberFactory.getOrCreateSubscriber(subscriptionId, messageReceiver);
+                    }
+                });
+    }
+
+    private MessageReceiver getOrCreateReceiver(final String tenantId) {
+        return activeReceivers.computeIfAbsent(tenantId, r -> createMessageReceiver(tenantId));
+    }
+
+    private MessageReceiver createMessageReceiver(final String tenantId) {
+        return (PubsubMessage message, AckReplyConsumer consumer) -> {
+            commandHandler.mapAndDelegateIncomingCommandMessage(message, tenantId);
+            consumer.ack();
+        };
+    }
+}

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandProcessingQueue.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandProcessingQueue.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.commandrouter.impl.pubsub;
+
+import java.util.Objects;
+
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommand;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommandContext;
+import org.eclipse.hono.commandrouter.impl.AbstractCommandProcessingQueue;
+
+import io.vertx.core.Vertx;
+
+/**
+ * Queue with the commands currently being processed.
+ * <p>
+ * The final step of processing a command, forwarding it to its target, is invoked here maintaining the order of the
+ * incoming commands.
+ * <p>
+ * Command order is maintained here across commands targeted at the same tenant/device. This is done by means of keeping
+ * different (sub-)queues, referenced by a queue key derived from the command tenant and the hash code of the command
+ * target device identifier.
+ */
+public class PubSubBasedCommandProcessingQueue
+        extends
+        AbstractCommandProcessingQueue<PubSubBasedCommandContext, PubSubBasedCommandProcessingQueue.TenantAndDeviceHashQueueKey> {
+
+    private static final int NUM_QUEUES_PER_TENANT = 8;
+
+    /**
+     * Creates a new PubSubCommandProcessingQueue.
+     *
+     * @param vertx The vert.x instance to use.
+     * @throws NullPointerException if vertx is {@code null}.
+     */
+    public PubSubBasedCommandProcessingQueue(final Vertx vertx) {
+        super(vertx);
+    }
+
+    @Override
+    protected TenantAndDeviceHashQueueKey getQueueKey(final PubSubBasedCommandContext commandContext) {
+        final PubSubBasedCommand command = commandContext.getCommand();
+        return new TenantAndDeviceHashQueueKey(command.getTenant(), command.getDeviceId());
+    }
+
+    @Override
+    protected String getCommandSourceForLog(final TenantAndDeviceHashQueueKey queueKey) {
+        return "address for tenant [" + queueKey.getTenantId() + "]";
+    }
+
+    /**
+     * Represents the key used for the queues map. Based on tenant identifier and an index derived from the device
+     * identifier hashcode.
+     */
+    static final class TenantAndDeviceHashQueueKey {
+
+        final String tenantId;
+        final int queueIndex;
+
+        TenantAndDeviceHashQueueKey(final String tenantId, final String deviceId) {
+            this.tenantId = Objects.requireNonNull(tenantId);
+            Objects.requireNonNull(deviceId);
+            this.queueIndex = deviceId.hashCode() % NUM_QUEUES_PER_TENANT;
+        }
+
+        /**
+         * Gets the tenant identifier.
+         * @return The tenant identifier.
+         */
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!getClass().isInstance(o)) {
+                return false;
+            }
+            final PubSubBasedCommandProcessingQueue.TenantAndDeviceHashQueueKey that = (PubSubBasedCommandProcessingQueue.TenantAndDeviceHashQueueKey) o;
+            return queueIndex == that.queueIndex && tenantId.equals(that.tenantId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(tenantId, queueIndex);
+        }
+    }
+}

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedMappingAndDelegatingCommandHandler.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.commandrouter.impl.pubsub;
+
+import java.util.Objects;
+
+import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommand;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommandContext;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommandResponseSender;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedInternalCommandSender;
+import org.eclipse.hono.client.pubsub.tracing.PubSubTracingHelper;
+import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
+import org.eclipse.hono.commandrouter.impl.AbstractMappingAndDelegatingCommandHandler;
+import org.eclipse.hono.commandrouter.impl.CommandProcessingQueue;
+import org.eclipse.hono.util.MessagingType;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.micrometer.core.instrument.Timer;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+
+/**
+ * A Handler for commands received at the tenant-specific topic.
+ */
+public class PubSubBasedMappingAndDelegatingCommandHandler
+        extends AbstractMappingAndDelegatingCommandHandler<PubSubBasedCommandContext> {
+
+    private final PubSubBasedCommandResponseSender pubSubBasedCommandResponseSender;
+
+    /**
+     * Creates a new PubSubBasedMappingAndDelegatingCommandHandler instance.
+     *
+     * @param vertx The Vert.x instance to use.
+     * @param tenantClient The Tenant service client.
+     * @param commandQueue The command processing queue instance to use.
+     * @param commandTargetMapper The mapper component to determine the command target.
+     * @param internalCommandSender The command sender to publish commands to the internal command topic.
+     * @param metrics The component to use for reporting metrics.
+     * @param tracer The tracer instance.
+     * @param pubSubBasedCommandResponseSender The sender used to send command responses.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public PubSubBasedMappingAndDelegatingCommandHandler(final Vertx vertx,
+            final TenantClient tenantClient,
+            final CommandProcessingQueue<PubSubBasedCommandContext> commandQueue,
+            final CommandTargetMapper commandTargetMapper,
+            final PubSubBasedInternalCommandSender internalCommandSender,
+            final CommandRouterMetrics metrics,
+            final Tracer tracer,
+            final PubSubBasedCommandResponseSender pubSubBasedCommandResponseSender) {
+        super(vertx, tenantClient, commandQueue, commandTargetMapper, internalCommandSender, metrics, tracer);
+        this.pubSubBasedCommandResponseSender = Objects.requireNonNull(pubSubBasedCommandResponseSender);
+    }
+
+    @Override
+    protected MessagingType getMessagingType() {
+        return MessagingType.pubsub;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The outcome of starting the command response sender and invoking
+     *         {@link AbstractMappingAndDelegatingCommandHandler#start()}.
+     */
+    @Override
+    public Future<Void> start() {
+        return CompositeFuture.all(super.start(), pubSubBasedCommandResponseSender.start()).mapEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return The outcome of stopping the command response sender and invoking
+     *         {@link AbstractMappingAndDelegatingCommandHandler#stop()}.
+     */
+    @Override
+    public Future<Void> stop() {
+        return CompositeFuture.join(super.stop(), pubSubBasedCommandResponseSender.stop()).mapEmpty();
+    }
+
+    /**
+     * Delegates an incoming command to the protocol adapter instance that the target device is connected to.
+     * <p>
+     * Determines the target gateway (if applicable) and protocol adapter instance for an incoming command and delegates
+     * the command to the resulting protocol adapter instance.
+     *
+     * @param pubsubMessage The Pub/Sub message corresponding to the command.
+     * @param tenantId The tenant this Pub/Sub message belongs to.
+     * @return A future indicating the outcome of the operation.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    public Future<Void> mapAndDelegateIncomingCommandMessage(final PubsubMessage pubsubMessage, final String tenantId) {
+        Objects.requireNonNull(pubsubMessage);
+        Objects.requireNonNull(tenantId);
+
+        final Timer.Sample timer = getMetrics().startTimer();
+        final PubSubBasedCommand command;
+        try {
+            command = PubSubBasedCommand.from(pubsubMessage, tenantId);
+        } catch (final IllegalArgumentException e) {
+            log.warn("Pub/Sub command message is invalid", e);
+            return Future.failedFuture("Pub/Sub command message is invalid");
+        }
+
+        final SpanContext spanContext = PubSubTracingHelper.extractSpanContext(tracer, pubsubMessage);
+        final Span currentSpan = createSpan(command.getTenant(), command.getDeviceId(), spanContext);
+        command.logToSpan(currentSpan);
+
+        final PubSubBasedCommandContext commandContext = new PubSubBasedCommandContext(
+                command,
+                pubSubBasedCommandResponseSender,
+                currentSpan);
+
+        if (!command.isValid()) {
+            log.debug("received invalid Pub/Sub command message [{}]", command);
+            return tenantClient.get(command.getTenant(), currentSpan.context())
+                    .compose(tenantConfig -> {
+                        commandContext.put(CommandContext.KEY_TENANT_CONFIG, tenantConfig);
+                        return Future.failedFuture("command is invalid");
+                    })
+                    .onComplete(ar -> {
+                        commandContext.reject("malformed command message");
+                        reportInvalidCommand(commandContext, timer);
+                    })
+                    .mapEmpty();
+        }
+        log.info("received valid command record [{}]", command);
+        return mapAndDelegateIncomingCommand(commandContext, timer);
+    }
+}

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedMappingAndDelegatingCommandHandlerTest.java
@@ -1,0 +1,234 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.hono.commandrouter.impl.pubsub;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.command.CommandContext;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommandContext;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedCommandResponseSender;
+import org.eclipse.hono.client.command.pubsub.PubSubBasedInternalCommandSender;
+import org.eclipse.hono.client.registry.TenantClient;
+import org.eclipse.hono.commandrouter.CommandRouterMetrics;
+import org.eclipse.hono.commandrouter.CommandTargetMapper;
+import org.eclipse.hono.test.TracingMockSupport;
+import org.eclipse.hono.test.VertxMockSupport;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.TenantObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.micrometer.core.instrument.Timer;
+import io.opentracing.Tracer;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Verifies behavior or {@link PubSubBasedMappingAndDelegatingCommandHandler}.
+ */
+public class PubSubBasedMappingAndDelegatingCommandHandlerTest {
+
+    private CommandTargetMapper commandTargetMapper;
+    private PubSubBasedInternalCommandSender internalCommandSender;
+    private Vertx vertx;
+    private String tenantId;
+    private String deviceId;
+    private String adapterInstanceId;
+
+    private PubSubBasedMappingAndDelegatingCommandHandler commandHandler;
+
+    /**
+     * Sets up fixture.
+     */
+    @BeforeEach
+    public void setUp() {
+        tenantId = UUID.randomUUID().toString();
+        deviceId = UUID.randomUUID().toString();
+        adapterInstanceId = UUID.randomUUID().toString();
+
+        final TenantClient tenantClient = mock(TenantClient.class);
+        when(tenantClient.get(eq(tenantId), any())).thenReturn(Future.succeededFuture(TenantObject.from(tenantId)));
+
+        commandTargetMapper = mock(CommandTargetMapper.class);
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId), any()))
+                .thenReturn(Future.succeededFuture(createTargetAdapterInstanceJson(deviceId, adapterInstanceId)));
+
+        internalCommandSender = mock(PubSubBasedInternalCommandSender.class);
+        when(internalCommandSender.sendCommand(
+                any(CommandContext.class),
+                anyString()))
+                        .thenReturn(Future.succeededFuture());
+
+        final PubSubBasedCommandResponseSender pubSubBasedCommandResponseSender = mock(
+                PubSubBasedCommandResponseSender.class);
+
+        vertx = mock(Vertx.class);
+        final Context context = VertxMockSupport.mockContext(vertx);
+        when(vertx.getOrCreateContext()).thenReturn(context);
+
+        final PubSubBasedCommandProcessingQueue commandQueue = new PubSubBasedCommandProcessingQueue(vertx);
+        final CommandRouterMetrics metrics = mock(CommandRouterMetrics.class);
+        when(metrics.startTimer()).thenReturn(Timer.start());
+        final Tracer tracer = TracingMockSupport.mockTracer(TracingMockSupport.mockSpan());
+        commandHandler = new PubSubBasedMappingAndDelegatingCommandHandler(
+                vertx,
+                tenantClient,
+                commandQueue,
+                commandTargetMapper,
+                internalCommandSender,
+                metrics,
+                tracer,
+                pubSubBasedCommandResponseSender);
+    }
+
+    /**
+     * Verifies the behavior of the
+     * {@link PubSubBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(PubsubMessage, String)} method
+     * in a scenario with a valid command message.
+     */
+    @Test
+    public void testCommandDelegationForValidCommand() {
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, "command-subject");
+
+        commandHandler.mapAndDelegateIncomingCommandMessage(message, tenantId);
+
+        final ArgumentCaptor<PubSubBasedCommandContext> commandContextArgumentCaptor = ArgumentCaptor
+                .forClass(PubSubBasedCommandContext.class);
+        verify(internalCommandSender, times(1)).sendCommand(
+                commandContextArgumentCaptor.capture(),
+                eq(adapterInstanceId));
+
+        final PubSubBasedCommandContext commandContext = commandContextArgumentCaptor.getValue();
+        assertNotNull(commandContext);
+        assertTrue(commandContext.getCommand().isValid());
+        assertEquals(tenantId, commandContext.getCommand().getTenant());
+        assertEquals(deviceId, commandContext.getCommand().getDeviceId());
+        assertEquals("command-subject", commandContext.getCommand().getName());
+    }
+
+    /**
+     * Verifies the behavior of the
+     * {@link PubSubBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(PubsubMessage, String)} method
+     * in a scenario with an invalid command message.
+     */
+    @Test
+    public void testCommandDelegationForInvalidCommandCatchException() {
+        final PubsubMessage message = getPubSubMessage(tenantId, null, "command-subject");
+
+        commandHandler.mapAndDelegateIncomingCommandMessage(message, tenantId);
+
+        verify(internalCommandSender, never()).sendCommand(
+                any(CommandContext.class),
+                anyString());
+    }
+
+    /**
+     * Verifies the behavior of the
+     * {@link PubSubBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(PubsubMessage, String)} method
+     * in a scenario with an invalid command message.
+     */
+    @Test
+    public void testCommandDelegationForInvalidCommand() {
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, null);
+
+        commandHandler.mapAndDelegateIncomingCommandMessage(message, tenantId);
+
+        verify(internalCommandSender, never()).sendCommand(
+                any(CommandContext.class),
+                anyString());
+    }
+
+    /**
+     * Verifies the behavior of the
+     * {@link PubSubBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(PubsubMessage, String)} method
+     * in a scenario where mapping/delegation of a valid command message times out.
+     */
+    @Test
+    public void testCommandDelegationTimesOut() {
+        VertxMockSupport.runTimersImmediately(vertx);
+
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, null);
+
+        final Future<Void> resultFuture = commandHandler.mapAndDelegateIncomingCommandMessage(message, tenantId);
+
+        verify(internalCommandSender, never()).sendCommand(
+                any(CommandContext.class),
+                anyString());
+        assertThat(resultFuture.failed()).isTrue();
+    }
+
+    /**
+     * Verifies the behavior of the
+     * {@link PubSubBasedMappingAndDelegatingCommandHandler#mapAndDelegateIncomingCommandMessage(PubsubMessage, String)} method
+     * in a scenario where no target adapter instance is found for the incoming command message.
+     */
+    @Test
+    public void testCommandDelegationWhenNoAdapterInstanceIsFound() {
+        final PubsubMessage message = getPubSubMessage(tenantId, deviceId, null);
+
+        when(commandTargetMapper.getTargetGatewayAndAdapterInstance(eq(tenantId), eq(deviceId), any()))
+                .thenReturn(Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND)));
+
+        commandHandler.mapAndDelegateIncomingCommandMessage(message, tenantId);
+
+        verify(internalCommandSender, never()).sendCommand(
+                any(CommandContext.class),
+                anyString());
+    }
+
+    private JsonObject createTargetAdapterInstanceJson(final String deviceId, final String otherAdapterInstance) {
+        final JsonObject targetAdapterInstanceJson = new JsonObject();
+
+        targetAdapterInstanceJson.put(DeviceConnectionConstants.FIELD_PAYLOAD_DEVICE_ID, deviceId);
+        targetAdapterInstanceJson.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID, otherAdapterInstance);
+
+        return targetAdapterInstanceJson;
+    }
+
+    private PubsubMessage getPubSubMessage(final String tenantId, final String deviceId, final String subject) {
+        final Map<String, String> attributes = new HashMap<>();
+        Optional.ofNullable(deviceId)
+                .ifPresent(ok -> attributes.put(MessageHelper.APP_PROPERTY_DEVICE_ID, deviceId));
+        Optional.ofNullable(tenantId)
+                .ifPresent(ok -> attributes.put(MessageHelper.APP_PROPERTY_TENANT_ID, tenantId));
+        Optional.ofNullable(subject)
+                .ifPresent(ok -> attributes.put(MessageHelper.SYS_PROPERTY_SUBJECT, subject));
+
+        return PubsubMessage.newBuilder().putAllAttributes(attributes).build();
+    }
+}


### PR DESCRIPTION
This is the last PR to use Pub/Sub as only messaging infrastructure. We added a Pub/Sub based implementation for Hono's Command Router API.

- Added new package to support a Pub/Sub based Command Router implementation.
- Integrate Command & Control implementation