### PR TITLE
[#3488] Enable subtopics for downstream messages with Pub/Sub messaging infrastructure

### DIFF
--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
@@ -103,7 +103,7 @@ public final class PubSubMessageHelper {
      * Gets the subtopics from the orig_address attribute of the message.
      *
      * @param origAddress The orig_address attribute.
-     * @return A list containing all the subtopics in hierarchical order or an empty list if the topic has no subtopics.
+     * @return An immutable list containing all the subtopics in hierarchical order or an empty immutable list if the topic has no subtopics.
      */
     public static List<String> getSubtopics(final String origAddress) {
         final String trimmedOrigAddress = origAddress.startsWith("/") ? origAddress.substring(1) : origAddress;
@@ -117,7 +117,7 @@ public final class PubSubMessageHelper {
         if (origAddressSplit.get(origAddressSplit.size() - 1).startsWith("?")) {
             origAddressSplit.remove(origAddressSplit.size() - 1);
         }
-        return origAddressSplit;
+        return Collections.unmodifiableList(origAddressSplit);
     }
 
     /**

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/PubSubMessageHelper.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.client.pubsub;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -78,7 +79,7 @@ public final class PubSubMessageHelper {
      * @return The topic containing the prefix identifier and the endpoint.
      */
     public static String getTopicName(final String topic, final String prefix) {
-        return getTopicName(topic, prefix, new ArrayList<>());
+        return getTopicName(topic, prefix, Collections.emptyList());
     }
 
     /**
@@ -99,19 +100,17 @@ public final class PubSubMessageHelper {
     }
 
     /**
-     * Gets the subtopics from the message attributes.
+     * Gets the subtopics from the orig_address attribute of the message.
      *
-     * @param attributesMap The attribute map.
-     * @return An ordered list containing all the subtopics.
+     * @param origAddress The orig_address attribute.
+     * @return A list containing all the subtopics in hierarchical order or an empty list if the topic has no subtopics.
      */
-    public static List<String> getSubtopics(final Map<String, String> attributesMap) {
-        String origAddress = getAttributesValue(attributesMap, MessageHelper.APP_PROPERTY_ORIG_ADDRESS)
-                .orElse("");
-        origAddress = origAddress.startsWith("/") ? origAddress.substring(1) : origAddress;
-        final List<String> origAddressSplit = new ArrayList<>(Arrays.stream(origAddress.split("/")).toList());
+    public static List<String> getSubtopics(final String origAddress) {
+        final String trimmedOrigAddress = origAddress.startsWith("/") ? origAddress.substring(1) : origAddress;
+        final List<String> origAddressSplit = new ArrayList<>(Arrays.stream(trimmedOrigAddress.split("/")).toList());
         // Subtopics are located starting at the 4th position (e.g. event/tenantId/deviceId/subtopic1/subtopic2/...).
         if (origAddressSplit.size() < 4) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
         origAddressSplit.subList(0, 3).clear();
         // Remove the last entry if it is a metadata property bag.
@@ -125,7 +124,7 @@ public final class PubSubMessageHelper {
      * Gets the subFolder from the list of subtopics.
      *
      * @param subtopics The list of subtopics.
-     * @return An string containing the subFolder.
+     * @return A string containing the subFolder.
      */
     public static String getSubFolder(final List<String> subtopics) {
         return String.join("/", subtopics);

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/CachingPubSubPublisherFactory.java
@@ -67,6 +67,11 @@ public final class CachingPubSubPublisherFactory implements PubSubPublisherFacto
     }
 
     @Override
+    public Future<Void> closePublisher(final String topic) {
+        return removePublisher(topic);
+    }
+
+    @Override
     public Future<Void> closePublisher(final String topic, final String prefix) {
         final String topicName = PubSubMessageHelper.getTopicName(topic, prefix);
         return removePublisher(topicName);

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherFactory.java
@@ -27,8 +27,7 @@ public interface PubSubPublisherFactory {
      * This method is expected to be invoked as soon as the publisher is no longer needed.
      *
      * @param topic The topic of the publisher to remove.
-     * @return A future that is completed when the close operation completed or a succeeded future if no publisher
-     *         existed with the given topic.
+     * @return A future that succeeds once the publisher is closed or if no publisher with the given topic exists.
      */
     Future<Void> closePublisher(String topic);
 
@@ -39,8 +38,7 @@ public interface PubSubPublisherFactory {
      *
      * @param topic The topic of the publisher to remove.
      * @param prefix The prefix of the topic of the publisher to remove, e.g. the tenantId.
-     * @return A future that is completed when the close operation completed or a succeeded future if no publisher
-     *         existed with the given topic.
+     * @return A future that succeeds once the publisher is closed or if no publisher with the given topic exists.
      */
     Future<Void> closePublisher(String topic, String prefix);
 

--- a/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherFactory.java
+++ b/clients/pubsub-common/src/main/java/org/eclipse/hono/client/pubsub/publisher/PubSubPublisherFactory.java
@@ -27,6 +27,17 @@ public interface PubSubPublisherFactory {
      * This method is expected to be invoked as soon as the publisher is no longer needed.
      *
      * @param topic The topic of the publisher to remove.
+     * @return A future that is completed when the close operation completed or a succeeded future if no publisher
+     *         existed with the given topic.
+     */
+    Future<Void> closePublisher(String topic);
+
+    /**
+     * Closes the publisher with the given topic if it exists.
+     * <p>
+     * This method is expected to be invoked as soon as the publisher is no longer needed.
+     *
+     * @param topic The topic of the publisher to remove.
      * @param prefix The prefix of the topic of the publisher to remove, e.g. the tenantId.
      * @return A future that is completed when the close operation completed or a succeeded future if no publisher
      *         existed with the given topic.

--- a/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
+++ b/clients/pubsub-common/src/test/java/org/eclipse/hono/client/pubsub/PubSubMessageHelperTest.java
@@ -66,12 +66,9 @@ public class PubSubMessageHelperTest {
     @Test
     public void testGetSubtopicsWithSubtopics() {
         final String metadata = "?metadata=true";
-        final Map<String, String> attributesMap = getAttributes(
-                MessageHelper.APP_PROPERTY_ORIG_ADDRESS,
-                String.format("%s/%s/%s/%s/%s/%s", topic, tenant, device, subtopic1, subtopic2, metadata),
-                "", "");
+        final String origAddress = String.format("%s/%s/%s/%s/%s/%s", topic, tenant, device, subtopic1, subtopic2, metadata);
 
-        final List<String> result = PubSubMessageHelper.getSubtopics(attributesMap);
+        final List<String> result = PubSubMessageHelper.getSubtopics(origAddress);
         assertThat(result).hasSize(2);
         assertThat(result.get(0)).isEqualTo(subtopic1);
         assertThat(result.get(1)).isEqualTo(subtopic2);
@@ -82,11 +79,9 @@ public class PubSubMessageHelperTest {
      */
     @Test
     public void testGetSubtopicsWithoutSubtopics() {
-        final Map<String, String> attributesMap = getAttributes(
-                MessageHelper.APP_PROPERTY_ORIG_ADDRESS, String.format("%s/%s/%s", topic, tenant, device),
-                "", "");
+        final String origAddress = String.format("%s/%s/%s", topic, tenant, device);
 
-        final List<String> result = PubSubMessageHelper.getSubtopics(attributesMap);
+        final List<String> result = PubSubMessageHelper.getSubtopics(origAddress);
         assertThat(result).isEmpty();
     }
 

--- a/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
+++ b/clients/telemetry-pubsub/src/main/java/org/eclipse/hono/client/telemetry/pubsub/PubSubBasedDownstreamSender.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.eclipse.hono.client.pubsub.AbstractPubSubBasedMessageSender;
 import org.eclipse.hono.client.pubsub.PubSubMessageHelper;
@@ -119,11 +118,12 @@ public final class PubSubBasedDownstreamSender extends AbstractPubSubBasedMessag
         final String tenantId = tenant.getTenantId();
         final String deviceId = device.getDeviceId();
 
-        final Map<String, String> propertiesStrings = properties.entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof String)
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        final String origAddress = Optional.ofNullable(properties.get(MessageHelper.APP_PROPERTY_ORIG_ADDRESS))
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .orElse("");
 
-        final List<String> subtopics = PubSubMessageHelper.getSubtopics(propertiesStrings);
+        final List<String> subtopics = PubSubMessageHelper.getSubtopics(origAddress);
         final String subFolder = PubSubMessageHelper.getSubFolder(subtopics);
         final Map<String, Object> propsWithDefaults = addDefaults(
                 EventConstants.EVENT_ENDPOINT,
@@ -165,11 +165,12 @@ public final class PubSubBasedDownstreamSender extends AbstractPubSubBasedMessag
         final String tenantId = tenant.getTenantId();
         final String deviceId = device.getDeviceId();
 
-        final Map<String, String> propertiesStrings = properties.entrySet().stream()
-                .filter(entry -> entry.getValue() instanceof String)
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        final String origAddress = Optional.ofNullable(properties.get(MessageHelper.APP_PROPERTY_ORIG_ADDRESS))
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .orElse("");
 
-        final List<String> subtopics = PubSubMessageHelper.getSubtopics(propertiesStrings);
+        final List<String> subtopics = PubSubMessageHelper.getSubtopics(origAddress);
         final String subFolder = PubSubMessageHelper.getSubFolder(subtopics);
         final Map<String, Object> propsWithDefaults = addDefaults(
                 TelemetryConstants.TELEMETRY_ENDPOINT,


### PR DESCRIPTION
Enable subtopic support in case Pub/Sub is used as the messaging infrastructure by checking if the topic contains subtopics and rerouting them to the respective Pub/Sub topic (e.g. MQTT topic event/exampleTenant/exampleDevice/subtopic to Pub/Sub topic exampleTenant.event.subtopic).

Implement a fallback mechanism in case the subtopic does not exist. In case the subtopic does not exist the message would instead get send to the "main" topic (e.g. telemetry or event).