### PR TITLE
[#3471] Bug fix for commands via Pub/Sub 

### DIFF
--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSender.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandSender.java
@@ -102,7 +102,10 @@ public class PubSubBasedInternalCommandSender extends AbstractPubSubBasedMessage
         attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_PROJECT_ID, projectId);
         attributes.put(PubSubMessageHelper.PUBSUB_PROPERTY_RESPONSE_REQUIRED, !command.isOneWay());
         Optional.ofNullable(command.getGatewayId()).ifPresent(
-                id -> attributes.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, id));
+                id -> {
+                    attributes.put(MessageHelper.APP_PROPERTY_GATEWAY_ID, id);
+                    attributes.put(MessageHelper.APP_PROPERTY_CMD_VIA, id);
+                });
         return attributes;
     }
 }


### PR DESCRIPTION
Fixed a bug preventing commands for a device being sent to the gateway representing the device if Pub/Sub is used as the messaging infrastructure resulting from the via header not being set.