### PR TITLE
Improve Kafka environment variable config documentation

### DIFF
--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -115,16 +115,19 @@ required to enable Kafka based messaging.
 The Kafka client configuration is composed of a number of properties that have an ambiguous mapping to environment
 variable names. For example, the property keys `a.b`, `a-b` and `a_b` would all map to the environment variable `A_B`.
 To resolve this ambiguity, the configuration framework relies on the correct property being defined in a configuration
-source with a lower presedence than the environment variable configuration source. It's therefore necessary to provide
+source with a lower precedence than the environment variable configuration source. It's therefore necessary to provide
 any such configuration property in the `application.yml` file or as a Java system property to help the configuration
 system disambiguate the property key, even if only providing a placeholder value. Once that has been done, it's 
 possible to override the value with an environment variable.
 {{% /notice %}}
 
 {{% notice tip %}}
-Any of the Kafka configuration options that use a period (`.`) in the key must use a double underscore in the 
-environment variable name. For example, the environment variable name to represent 
-`hono.kafka.commonClientConfig."bootstrap.servers"` is `HONO_KAFKA_COMMONCLIENTCONFIG__BOOTSTRAP_SERVERS__`.
+Some of the Kafka configuration options beneath `hono.kafka.commonClientConfig` need to be quoted as the keys themselves
+can contain hierarchical delimiters such as a period (`.`). An example of that is `bootstrap.servers` which is a single
+key within the `hono.kafka.commonClientConfig` configuration map.
+To represent such a key with an environment variable, you must use double underscores for representing the quoted key. 
+For example, the environment variable to represent `hono.kafka.commonClientConfig."bootstrap.servers"` is 
+`HONO_KAFKA_COMMONCLIENTCONFIG__BOOTSTRAP_SERVERS__`.
 {{% /notice %}}
 
 ## Using TLS

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -111,6 +111,22 @@ The Kafka clients require at least the `bootstrap.servers` property to be set. T
 required to enable Kafka based messaging.
 {{% /notice %}}
 
+{{% notice tip %}}
+The Kafka client configuration is composed of a number of properties that have an ambiguous mapping to environment
+variable names. For example, the property keys `a.b`, `a-b` and `a_b` would all map to the environment variable `A_B`.
+To resolve this ambiguity, the configuration framework relies on the correct property being defined in a configuration
+source with a lower presedence than the environment variable configuration source. It's therefore necessary to provide
+any such configuration property in the `application.yml` file or as a Java system property to help the configuration
+system disambiguate the property key, even if only providing a placeholder value. Once that has been done, it's 
+possible to override the value provided with an environment variable.
+{{% /notice %}}
+
+{{% notice tip %}}
+Any of the Kafka configuration options that use a period (`.`) in the key must use a double underscore in the 
+environment variable name. For example, the environment variable name to represent 
+`hono.kafka.commonClientConfig."bootstrap.servers"` is `HONO_KAFKA_COMMONCLIENTCONFIG__BOOTSTRAP_SERVERS__`.
+{{% /notice %}}
+
 ## Using TLS
 
 The factory can be configured to use TLS for authenticating the brokers in the Kafka cluster during connection

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -118,7 +118,7 @@ To resolve this ambiguity, the configuration framework relies on the correct pro
 source with a lower presedence than the environment variable configuration source. It's therefore necessary to provide
 any such configuration property in the `application.yml` file or as a Java system property to help the configuration
 system disambiguate the property key, even if only providing a placeholder value. Once that has been done, it's 
-possible to override the value provided with an environment variable.
+possible to override the value with an environment variable.
 {{% /notice %}}
 
 {{% notice tip %}}

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -115,7 +115,7 @@ required to enable Kafka based messaging.
 The Kafka client configuration is composed of a number of properties that have an ambiguous mapping to environment
 variable names. For example, the property key `"bootstrap.servers"` in the `hono.kafka.commonClientConfig` map would
 have the same mapping to an environment variable as `"bootstrap-servers"` and `"bootstrap_servers"` (they would all map
-to `__BOOTSTRAP_SERVER__`).
+to `__BOOTSTRAP_SERVERS__`).
 
 To resolve this ambiguity and allow ambiguous properties to be overridden using environment variables, the configuration 
 framework relies on the correct property being defined in a configuration source which uses unambiguous property key 

--- a/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
+++ b/site/documentation/content/admin-guide/hono-kafka-client-configuration.md
@@ -113,12 +113,15 @@ required to enable Kafka based messaging.
 
 {{% notice tip %}}
 The Kafka client configuration is composed of a number of properties that have an ambiguous mapping to environment
-variable names. For example, the property keys `a.b`, `a-b` and `a_b` would all map to the environment variable `A_B`.
-To resolve this ambiguity, the configuration framework relies on the correct property being defined in a configuration
-source with a lower precedence than the environment variable configuration source. It's therefore necessary to provide
-any such configuration property in the `application.yml` file or as a Java system property to help the configuration
-system disambiguate the property key, even if only providing a placeholder value. Once that has been done, it's 
-possible to override the value with an environment variable.
+variable names. For example, the property key `"bootstrap.servers"` in the `hono.kafka.commonClientConfig` map would
+have the same mapping to an environment variable as `"bootstrap-servers"` and `"bootstrap_servers"` (they would all map
+to `__BOOTSTRAP_SERVER__`).
+
+To resolve this ambiguity and allow ambiguous properties to be overridden using environment variables, the configuration 
+framework relies on the correct property being defined in a configuration source which uses unambiguous property key 
+representations and has a lower precedence than the environment variable configuration source. It's therefore necessary 
+to provide any such configuration property in the `application.yml` file or as a Java system property to help the 
+configuration system disambiguate the property key, even if only providing a placeholder value.
 {{% /notice %}}
 
 {{% notice tip %}}


### PR DESCRIPTION
Add documenation about dynamic config keys and the need to disambiguate them in the config file or as system properties. Also explain the need to use double underscore for properties that include a period in their key.