### PR TITLE
WIP: Add redis backed cache as alternative for infinispan

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -328,6 +328,26 @@ quarkus.vertx.max-event-loop-execute-time=${max.event-loop.execute-time:20000}
       </dependency>
       <dependency>
         <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-cache-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-cache-infinispan</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-cache-redis</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-client-device-connection</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.hono</groupId>
         <artifactId>hono-client-common</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/caches/cache-common/pom.xml
+++ b/caches/cache-common/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-caches-parent</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-cache-common</artifactId>
+
+    <name>Hono Cache Common</name>
+    <description>Classes required for implementing Hono caches</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager-embedded</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-development-mode-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-bootstrap-runner</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.slf4j</groupId>
+                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.graalvm.sdk</groupId>
+                    <artifactId>graal-sdk</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-fs-util</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!--
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.opentracing</groupId>
+                    <artifactId>opentracing-noop</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-health-check</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-auth-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+-->
+        <!-- testing -->
+        <!--
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+-->
+    </dependencies>
+</project>

--- a/caches/cache-common/src/main/java/org/eclipse/hono/cache/Cache.java
+++ b/caches/cache-common/src/main/java/org/eclipse/hono/cache/Cache.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.cache;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A simple {@code Map} like interface to a data grid cache.
+ *
+ * @param <K> The type of keys used for looking up data.
+ * @param <V> The type of values stored in grid.
+ */
+public interface Cache<K, V> {
+
+    /**
+     * Checks if the cache is connected to the data grid.
+     * <p>
+     * If a cache is found to be not connected here, this method may trigger a connection (re)establishment.
+     *
+     * @return A future that is completed with information about a successful check's result.
+     *         Otherwise, the future will be failed with a
+     *         {@link org.eclipse.hono.client.ServerErrorException}.
+     */
+    Future<JsonObject> checkForCacheAvailability();
+
+    /**
+     * Puts a value to the cache.
+     *
+     * @param key The key.
+     * @param value The value.
+     * @return A succeeded future if the value has been stored successfully.
+     *         A failed future if the value could not be stored in the cache.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> put(K key, V value);
+
+    /**
+     * Puts a value to the cache.
+     *
+     * @param key The key.
+     * @param value The value.
+     * @param lifespan The lifespan of the entry. A negative value is interpreted as an unlimited lifespan.
+     * @param lifespanUnit The time unit for the lifespan.
+     * @return A succeeded future if the value has been stored successfully.
+     *         A failed future if the value could not be stored in the cache.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> put(K key, V value, long lifespan, TimeUnit lifespanUnit);
+
+    /**
+     * Puts all values of the given map to the cache.
+     *
+     * @param data The map with the entries to add.
+     * @return A succeeded future if the operation succeeded.
+     *         A failed future if there was an error storing the entries in the cache.
+     * @throws NullPointerException if data is {@code null}.
+     */
+    Future<Void> putAll(Map<? extends K, ? extends V> data);
+
+    /**
+     * Puts all values of the given map to the cache.
+     *
+     * @param data The map with the entries to add.
+     * @param lifespan The lifespan of the entries. A negative value is interpreted as an unlimited lifespan.
+     * @param lifespanUnit The time unit for the lifespan.
+     * @return A succeeded future if the operation succeeded.
+     *         A failed future if there was an error storing the entries in the cache.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> putAll(Map<? extends K, ? extends V> data, long lifespan, TimeUnit lifespanUnit);
+
+    /**
+     * Gets a value from the cache.
+     *
+     * @param key The key.
+     * @return A succeeded future containing the value or {@code null} if the
+     *         cache didn't contain the key yet.
+     *         A failed future if the value could not be read from the cache.
+     * @throws NullPointerException if key is {@code null}.
+     */
+    Future<V> get(K key);
+
+    /**
+     * Removes a key/value mapping from the cache.
+     *
+     * @param key The key.
+     * @param value The value.
+     * @return A succeeded future containing {@code true} if the key was
+     *         mapped to the value, {@code false} otherwise.
+     *         A failed future if the value could not be removed from the cache.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Boolean> remove(K key, V value);
+
+    /**
+     * Gets the values for the specified keys from the cache.
+     *
+     * @param keys The keys.
+     * @return A succeeded future containing a map with key/value pairs.
+     * @throws NullPointerException if keys is {@code null}.
+     */
+    Future<Map<K, V>> getAll(Set<? extends K> keys);
+}

--- a/caches/cache-common/src/main/java/org/eclipse/hono/cache/CommonCacheConfig.java
+++ b/caches/cache-common/src/main/java/org/eclipse/hono/cache/CommonCacheConfig.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.cache;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Common cache configuration options.
+ */
+public class CommonCacheConfig {
+
+    /**
+     * The default name of the (remote) cache in the data grid that is used for
+     * storing device connection information.
+     */
+    public static final String DEFAULT_CACHE_NAME = "device-connection";
+
+    private String cacheName = DEFAULT_CACHE_NAME;
+
+    private String checkKey = "KEY_CONNECTION_CHECK";
+    private String checkValue = "VALUE_CONNECTION_CHECK";
+
+    /**
+     * Creates properties for default values.
+     */
+    public CommonCacheConfig() {
+        super();
+    }
+
+    /**
+     * Creates properties for existing options.
+     *
+     * @param options The options to copy.
+     */
+    public CommonCacheConfig(final CommonCacheOptions options) {
+        super();
+        this.cacheName = options.cacheName();
+        this.checkKey = options.checkKey();
+        this.checkValue = options.checkValue();
+    }
+
+    public void setCacheName(final String cacheName) {
+        this.cacheName = cacheName;
+    }
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public void setCheckKey(final String checkKey) {
+        this.checkKey = checkKey;
+    }
+
+    public String getCheckKey() {
+        return checkKey;
+    }
+
+    public void setCheckValue(final String checkValue) {
+        this.checkValue = checkValue;
+    }
+
+    public String getCheckValue() {
+        return checkValue;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects
+                .toStringHelper(this)
+                .add("cacheName", this.cacheName)
+                .add("checkKey", this.checkKey)
+                .add("checkValue", this.checkValue)
+                .toString();
+    }
+}

--- a/caches/cache-common/src/main/java/org/eclipse/hono/cache/CommonCacheOptions.java
+++ b/caches/cache-common/src/main/java/org/eclipse/hono/cache/CommonCacheOptions.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.cache;
+
+import org.eclipse.hono.util.CommandRouterConstants;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.ConfigMapping.NamingStrategy;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Common options for configuring a cache.
+ *
+ */
+@ConfigMapping(prefix = "hono.cache.common", namingStrategy = NamingStrategy.VERBATIM)
+public interface CommonCacheOptions {
+
+    /**
+     * Gets the name of the cache.
+     *
+     * @return The name.
+     */
+    @WithDefault(CommandRouterConstants.DEFAULT_CACHE_NAME)
+    String cacheName();
+
+    /**
+     * Gets the key to use for checking the cache's availability.
+     *
+     * @return The key.
+     */
+    @WithDefault("KEY_CONNECTION_CHECK")
+    String checkKey();
+
+    /**
+     * The value to use for checking the cache's availability.
+     *
+     * @return The value.
+     */
+    @WithDefault("VALUE_CONNECTION_CHECK")
+    String checkValue();
+}

--- a/caches/cache-infinispan/pom.xml
+++ b/caches/cache-infinispan/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-caches-parent</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-cache-infinispan</artifactId>
+
+    <name>Hono Client Device Connection Cache using Infinispan</name>
+    <description>Infinispan implementation of Hono's Client Device Connection cache</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-cache-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-client-hotrod</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-query-dsl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager-embedded</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-development-mode-spi</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-bootstrap-runner</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.slf4j</groupId>
+                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.graalvm.sdk</groupId>
+                    <artifactId>graal-sdk</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-fs-util</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- testing -->
+        <!--
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+-->
+    </dependencies>
+</project>

--- a/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/BasicCache.java
+++ b/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/BasicCache.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection.infinispan;
+
+import java.net.HttpURLConnection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+
+import org.eclipse.hono.cache.Cache;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.util.Futures;
+import org.eclipse.hono.util.Lifecycle;
+import org.infinispan.commons.api.BasicCacheContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
+/**
+ * An abstract base class for implementing caches based on an
+ * Infinispan {@link org.infinispan.commons.api.BasicCache}.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public abstract class BasicCache<K, V> implements Cache<K, V>, Lifecycle {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BasicCache.class);
+
+    protected final Vertx vertx;
+    private final BasicCacheContainer cacheManager;
+    private final AtomicBoolean stopCalled = new AtomicBoolean();
+
+    private org.infinispan.commons.api.BasicCache<K, V> cache;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param vertx The vert.x instance to run on.
+     * @param cacheManager The cache manager.
+     */
+    protected BasicCache(final Vertx vertx, final BasicCacheContainer cacheManager) {
+        this.vertx = Objects.requireNonNull(vertx);
+        this.cacheManager = Objects.requireNonNull(cacheManager);
+    }
+
+    /**
+     * Called to trigger connecting the cache.
+     *
+     * @return A future tracking the progress, never returns {@code null}.
+     */
+    protected abstract Future<Void> connectToCache();
+
+    /**
+     * Checks if the cache manager is started.
+     *
+     * @return {@code true} if the cache manager is started, {@code false} otherwise.
+     */
+    protected abstract boolean isStarted();
+
+    @Override
+    public Future<Void> start() {
+        LOG.info("starting cache");
+        return connectToCache();
+    }
+
+    @Override
+    public Future<Void> stop() {
+        if (!stopCalled.compareAndSet(false, true)) {
+            return Future.succeededFuture();
+        }
+        LOG.info("stopping cache");
+        setCache(null);
+        final Promise<Void> result = Promise.promise();
+        vertx.executeBlocking(r -> {
+            try {
+                cacheManager.stop();
+                r.complete();
+            } catch (final Exception t) {
+                r.fail(t);
+            }
+        }, (AsyncResult<Void> stopAttempt) -> {
+            if (stopAttempt.succeeded()) {
+                LOG.info("connection(s) to cache stopped successfully");
+            } else {
+                LOG.info("error trying to stop connection(s) to cache", stopAttempt.cause());
+            }
+            result.handle(stopAttempt);
+        });
+        return result.future();
+    }
+
+    protected void setCache(final org.infinispan.commons.api.BasicCache<K, V> cache) {
+        this.cache = cache;
+    }
+
+    protected org.infinispan.commons.api.BasicCache<K, V> getCache() {
+        return this.cache;
+    }
+
+    /**
+     * Performs a task with a connected cache.
+     * <p>
+     * The method checks if the cache instance has been set. If that is the case, then the
+     * supplier will be invoked, providing a <em>non-null</em> cache instance.
+     * <p>
+     * If the cache has not been set (yet) or it has been stopped, the supplier will not be
+     * called and a failed future will be returned, provided by {@link #noConnectionFailure()}.
+     *
+     * @param <T> The type of the return value.
+     * @param futureSupplier The supplier, providing the operation which should be invoked.
+     * @return The future, tracking the result of the operation.
+     */
+    protected final <T> Future<T> withCache(
+            final Function<org.infinispan.commons.api.BasicCache<K, V>, CompletionStage<T>> futureSupplier) {
+
+        return Optional.ofNullable(cache)
+                .map(c -> Futures.create(() -> futureSupplier.apply(c)))
+                .orElseGet(BasicCache::noConnectionFailure)
+                .onComplete(this::postCacheAccess);
+    }
+
+    /**
+     * Performs extra processing on the result of a cache operation returned by {@link #withCache(Function)}.
+     * <p>
+     * Subclasses should override this method if needed.
+     * <p>
+     * This default implementation does nothing.
+     *
+     * @param <T> The type of the return value.
+     * @param cacheOperationResult The result of the cache operation.
+     */
+    protected  <T> void postCacheAccess(final AsyncResult<T> cacheOperationResult) {
+        // nothing done by default
+    }
+
+    @Override
+    public Future<Void> put(final K key, final V value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+
+        return withCache(aCache -> aCache.putAsync(key, value).thenApply(v -> (Void) null));
+    }
+
+    @Override
+    public Future<Void> put(final K key, final V value, final long lifespan, final TimeUnit lifespanUnit) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+        Objects.requireNonNull(lifespanUnit);
+
+        return withCache(aCache -> aCache.putAsync(key, value, lifespan, lifespanUnit).thenApply(v -> (Void) null));
+    }
+
+    @Override
+    public Future<Void> putAll(final Map<? extends K, ? extends V> data) {
+        Objects.requireNonNull(data);
+
+        return withCache(aCache -> aCache.putAllAsync(data));
+    }
+
+    @Override
+    public Future<Void> putAll(final Map<? extends K, ? extends V> data, final long lifespan, final TimeUnit lifespanUnit) {
+        Objects.requireNonNull(data);
+        Objects.requireNonNull(lifespanUnit);
+
+        return withCache(aCache -> aCache.putAllAsync(data, lifespan, lifespanUnit));
+    }
+
+    @Override
+    public Future<Boolean> remove(final K key, final V value) {
+        Objects.requireNonNull(key);
+        Objects.requireNonNull(value);
+
+        return withCache(aCache -> aCache.removeAsync(key, value));
+    }
+
+    @Override
+    public Future<V> get(final K key) {
+        Objects.requireNonNull(key);
+
+        return withCache(aCache -> aCache.getAsync(key));
+    }
+
+    @Override
+    public Future<Map<K, V>> getAll(final Set<? extends K> keys) {
+        Objects.requireNonNull(keys);
+
+        return withCache(aCache -> aCache.getAllAsync(keys));
+    }
+
+    /**
+     * Returns a failed future, reporting a missing connection to the cache.
+     *
+     * @param <V> The value type of the returned future.
+     * @return A failed future, never returns {@code null}.
+     */
+    protected static <V> Future<V> noConnectionFailure() {
+
+        return Future.failedFuture(new ServerErrorException(
+                HttpURLConnection.HTTP_UNAVAILABLE, "no connection to data grid"));
+    }
+
+}

--- a/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/EmbeddedCache.java
+++ b/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/EmbeddedCache.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection.infinispan;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * An embedded cache.
+ *
+ * @param <K> The type of keys used by the cache.
+ * @param <V> The type of values stored in the cache.
+ */
+public class EmbeddedCache<K, V> extends BasicCache<K, V> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedCache.class);
+
+    private final AtomicBoolean connecting = new AtomicBoolean(false);
+
+    private final EmbeddedCacheManager cacheManager;
+    private final String cacheName;
+
+    /**
+     * Creates a new embedded cache instance.
+     *
+     * @param vertx The vert.x instance to run on.
+     * @param cacheManager The connection to the cache.
+     * @param cacheName The name of the cache.
+     */
+    public EmbeddedCache(
+            final Vertx vertx,
+            final EmbeddedCacheManager cacheManager,
+            final String cacheName) {
+        super(vertx, cacheManager);
+        this.cacheManager = Objects.requireNonNull(cacheManager);
+        this.cacheName = Objects.requireNonNull(cacheName);
+    }
+
+    @Override
+    protected boolean isStarted() {
+        return cacheManager.isRunning(cacheName) && getCache() != null;
+    }
+
+    @Override
+    protected Future<Void> connectToCache() {
+
+        final Promise<Void> result = Promise.promise();
+
+        if (connecting.compareAndSet(false, true)) {
+
+            vertx.executeBlocking(r -> {
+                try {
+                    LOG.debug("trying to start cache manager");
+                    cacheManager.start();
+                    LOG.info("started cache manager");
+                    LOG.debug("trying to get cache");
+                    setCache(cacheManager.getCache(cacheName));
+                    if (isStarted()) {
+                        r.complete(getCache());
+                    } else {
+                        r.fail(new IllegalStateException("cache [" + cacheName + "] is not configured"));
+                    }
+                } catch (final Throwable t) {
+                    r.fail(t);
+                }
+            }, attempt -> {
+                if (attempt.succeeded()) {
+                    LOG.info("successfully connected to cache");
+                    result.complete();
+                } else {
+                    LOG.debug("failed to connect to cache: {}", attempt.cause().getMessage());
+                    result.fail(attempt.cause());
+                }
+                connecting.set(false);
+            });
+        } else {
+            LOG.info("already trying to establish connection to cache");
+            result.fail("already trying to establish connection to cache");
+        }
+        return result.future();
+    }
+
+    @Override
+    public Future<JsonObject> checkForCacheAvailability() {
+
+        if (isStarted()) {
+            return Future.succeededFuture(new JsonObject());
+        } else {
+            // try to (re-)establish connection
+            connectToCache();
+            return Future.failedFuture("not connected to cache");
+        }
+    }
+
+}

--- a/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/HotrodCache.java
+++ b/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/HotrodCache.java
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection.infinispan;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.hono.cache.CommonCacheConfig;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheContainer;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.commons.marshall.ProtoStreamMarshaller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A remote cache that connects to a data grid using the Hotrod protocol.
+ *
+ * @param <K> The type of keys used by the cache.
+ * @param <V> The type of values stored in the cache.
+ */
+public final class HotrodCache<K, V> extends BasicCache<K, V> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HotrodCache.class);
+
+    /**
+     * Maximum age for a cached connection check result to be used in {@link #checkForCacheAvailability()}.
+     */
+    private static final Duration CACHED_CONNECTION_CHECK_RESULT_MAX_AGE = Duration.ofSeconds(30);
+
+    private final AtomicBoolean connecting = new AtomicBoolean(false);
+    private final RemoteCacheContainer cacheManager;
+    private final String cacheName;
+
+    private final K connectionCheckKey;
+    private final V connectionCheckValue;
+
+    private ConnectionCheckResult lastConnectionCheckResult;
+
+    /**
+     * Creates a new HotrodCache instance.
+     *
+     * @param vertx The vert.x instance to run on.
+     * @param cacheManager The connection to the remote cache.
+     * @param cacheName The name of the (remote) cache.
+     * @param connectionCheckKey The key to use for checking the connection
+     *                           to the data grid.
+     * @param connectionCheckValue The value to use for checking the connection
+     *                           to the data grid.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    HotrodCache(
+            final Vertx vertx,
+            final RemoteCacheContainer cacheManager,
+            final String cacheName,
+            final K connectionCheckKey,
+            final V connectionCheckValue) {
+        super(vertx, cacheManager);
+        this.cacheManager = Objects.requireNonNull(cacheManager);
+        this.cacheName = Objects.requireNonNull(cacheName);
+        this.connectionCheckKey = Objects.requireNonNull(connectionCheckKey);
+        this.connectionCheckValue = Objects.requireNonNull(connectionCheckValue);
+    }
+
+    /**
+     * Creates a new remote cache.
+     *
+     * @param vertx The vert.x instance to run on.
+     * @param properties The remote cache configuration.
+     * @param commonCacheConfig The common cache configuration.
+     * @return The remote cache.
+     * @throws NullPointerException if any of the parameters are {@code null}.
+     */
+    public static HotrodCache<String, String> from(
+            final Vertx vertx,
+            final InfinispanRemoteConfigurationProperties properties,
+            final CommonCacheConfig commonCacheConfig) {
+
+        Objects.requireNonNull(vertx);
+        Objects.requireNonNull(properties);
+        Objects.requireNonNull(commonCacheConfig);
+
+        final var configBuilder = properties.getConfigurationBuilder();
+        configBuilder.marshaller(new ProtoStreamMarshaller());
+        final var configuration = configBuilder.build();
+        if (LOG.isInfoEnabled()) {
+            LOG.info("creating HotrodCache using configuration: {}", configuration);
+        }
+        return new HotrodCache<>(
+                vertx,
+                new RemoteCacheManager(configuration, false),
+                commonCacheConfig.getCacheName(),
+                commonCacheConfig.getCheckKey(),
+                commonCacheConfig.getCheckValue());
+    }
+
+    @Override
+    protected Future<Void> connectToCache() {
+
+        final Promise<Void> result = Promise.promise();
+
+        if (connecting.compareAndSet(false, true)) {
+
+            vertx.executeBlocking(r -> {
+                try {
+                    if (!cacheManager.isStarted()) {
+                        LOG.debug("trying to start cache manager");
+                        cacheManager.start();
+                        LOG.info("started cache manager, now connecting to remote cache");
+                    }
+                    LOG.debug("trying to connect to remote cache");
+                    @SuppressWarnings("unchecked")
+                    final var cache = (RemoteCache<K, V>) cacheManager.getCache(cacheName);
+                    if (cache == null) {
+                        r.fail(new IllegalStateException("remote cache [" + cacheName + "] does not exist"));
+                    } else {
+                        cache.start();
+                        setCache(cache);
+                        r.complete(cache);
+                    }
+                } catch (final Exception t) {
+                    r.fail(t);
+                }
+            }, attempt -> {
+                if (attempt.succeeded()) {
+                    LOG.info("successfully connected to remote cache");
+                    result.complete();
+                } else {
+                    LOG.debug("failed to connect to remote cache: {}", attempt.cause().getMessage());
+                    result.fail(attempt.cause());
+                }
+                connecting.set(false);
+            });
+        } else {
+            LOG.info("already trying to establish connection to data grid");
+            result.fail("already trying to establish connection to data grid");
+        }
+        return result.future();
+    }
+
+    @Override
+    protected boolean isStarted() {
+        return cacheManager.isStarted() && getCache() != null;
+    }
+
+    @Override
+    protected <T> void postCacheAccess(final AsyncResult<T> cacheOperationResult) {
+        lastConnectionCheckResult = new ConnectionCheckResult(cacheOperationResult.cause());
+    }
+
+    /**
+     * Checks if the cache is connected.
+     *
+     * @return A future that is completed with information about a successful check's result.
+     *         Otherwise, the future will be failed with a {@link org.eclipse.hono.client.ServerErrorException}.
+     */
+    @Override
+    public Future<JsonObject> checkForCacheAvailability() {
+
+        if (isStarted()) {
+            final ConnectionCheckResult lastResult = lastConnectionCheckResult;
+            if (lastResult != null && !lastResult.isOlderThan(CACHED_CONNECTION_CHECK_RESULT_MAX_AGE)) {
+                return lastResult.asFuture();
+            } else {
+                final Promise<JsonObject> result = Promise.promise();
+                put(connectionCheckKey, connectionCheckValue)
+                        .onComplete(r -> {
+                            if (r.succeeded()) {
+                                result.complete(new JsonObject());
+                            } else {
+                                LOG.debug("failed to put test value to cache", r.cause());
+                                result.fail(r.cause());
+                            }
+                        });
+                return result.future();
+            }
+        } else {
+            // try to (re-)establish connection
+            connectToCache();
+            return Future.failedFuture("not connected to data grid");
+        }
+    }
+
+    /**
+     * Keeps the result of a connection check.
+     */
+    private static class ConnectionCheckResult {
+        private final Instant creationTimestamp = Instant.now();
+        private final Throwable errorResult;
+
+        /**
+         * Creates a new ConnectionCheckResult.
+         *
+         * @param errorResult The error in case the check failed; use {@code null} if the check succeeded.
+         */
+        ConnectionCheckResult(final Throwable errorResult) {
+            this.errorResult = errorResult;
+        }
+
+        /**
+         * Checks if the result is older than the given time span, determined from the current point in time.
+         *
+         * @param timespan The time span.
+         * @return {@code true} if the result is older.
+         */
+        public boolean isOlderThan(final Duration timespan) {
+            return creationTimestamp.isBefore(Instant.now().minus(timespan));
+        }
+
+        /**
+         * Gets a future indicating the connection check outcome.
+         *
+         * @return A succeeded future if the check succeeded, otherwise a failed future.
+         */
+        public Future<JsonObject> asFuture() {
+            return errorResult != null ? Future.failedFuture(errorResult) : Future.succeededFuture(new JsonObject());
+        }
+    }
+
+}

--- a/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/InfinispanRemoteConfigurationOptions.java
+++ b/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/InfinispanRemoteConfigurationOptions.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceconnection.infinispan;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.ConfigMapping.NamingStrategy;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Options for configuring a Hotrod connection to a remote cache.
+ *
+ */
+@ConfigMapping(prefix = "hono.cache.infinispan", namingStrategy = NamingStrategy.VERBATIM)
+public interface InfinispanRemoteConfigurationOptions {
+
+    /**
+     * Gets the connection pool options.
+     *
+     * @return The options.
+     */
+    Map<String, String> connectionPool();
+
+    /**
+     * Gets the default executor factory options.
+     *
+     * @return The options.
+     */
+    Map<String, String> defaultExecutorFactory();
+
+    /**
+     * Gets the SASL properties.
+     *
+     * @return The properties.
+     */
+    Map<String, String> saslProperties();
+
+    /**
+     * Gets the cluster options.
+     *
+     * @return The options.
+     */
+    Map<String, String> cluster();
+
+    /**
+     * Gets the list of remote servers as a string of the form <em>host1[:port][;host2[:port]]</em>.
+     *
+     * @return The servers.
+     */
+    Optional<String> serverList();
+
+    /**
+     * Gets the auth server name.
+     *
+     * @return The server name.
+     */
+    Optional<String> authServerName();
+
+    /**
+     * Gets the user name to use for authentication.
+     *
+     * @return The user name.
+     */
+    Optional<String> authUsername();
+
+    /**
+     * Gets the password to use for authentication.
+     *
+     * @return The password.
+     */
+    Optional<String> authPassword();
+
+    /**
+     * Gets the auth realm (for DIGEST-MD5 authentication).
+     *
+     * @return The realm.
+     */
+    Optional<String> authRealm();
+
+    /**
+     * Gets the SASL mechanism to use for authentication.
+     *
+     * @return The mechanism.
+     */
+    Optional<String> saslMechanism();
+
+    /**
+     * Gets the socket timeout.
+     *
+     * @return The timeout.
+     */
+    @WithDefault("60000")
+    int socketTimeout();
+
+    /**
+     * Gets the connect timeout.
+     *
+     * @return The timeout.
+     */
+    @WithDefault("60000")
+    int connectTimeout();
+
+    /**
+     * Gets the path of the trust store.
+     *
+     * @return The path.
+     */
+    Optional<String> trustStorePath();
+
+    /**
+     * Gets the trust store file name.
+     *
+     * @return The file name.
+     */
+    Optional<String> trustStoreFileName();
+
+    /**
+     * Gets the type of the trust store (JKS, JCEKS, PCKS12 or PEM).
+     *
+     * @return The type.
+     */
+    Optional<String> trustStoreType();
+
+    /**
+     * Gets the password of the trust store.
+     *
+     * @return The password.
+     */
+    Optional<String> trustStorePassword();
+
+    /**
+     * Gets the file name of a keystore to use when using client certificate authentication.
+     *
+     * @return The file name.
+     */
+    Optional<String> keyStoreFileName();
+
+    /**
+     * Gets the keystore type.
+     *
+     * @return The type.
+     */
+    Optional<String> keyStoreType();
+
+    /**
+     * Gets the keystore password.
+     *
+     * @return The password.
+     */
+    Optional<String> keyStorePassword();
+
+    /**
+     * Gets the key alias.
+     *
+     * @return The alias.
+     */
+    Optional<String> keyAlias();
+
+    /**
+     * Gets the certificate password in the keystore.
+     *
+     * @return The password.
+     */
+    Optional<String> keyStoreCertificatePassword();
+
+    /**
+     * Checks whether TLS is enabled.
+     *
+     * @return {@code true} if TLS is enabled.
+     */
+    @WithDefault("false")
+    boolean useSsl();
+
+    /**
+     * Gets the list of ciphers, separated with spaces and in order of preference, that are used during the TLS
+     * handshake.
+     *
+     * @return The ciphers.
+     */
+    Optional<String> sslCiphers();
+
+    /**
+     * Gets the TLS protocol to use (e.g. TLSv1.2).
+     *
+     * @return The protocol.
+     */
+    Optional<String> sslProtocol();
+}

--- a/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/InfinispanRemoteConfigurationProperties.java
+++ b/caches/cache-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/InfinispanRemoteConfigurationProperties.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceconnection.infinispan;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.base.MoreObjects;
+
+
+/**
+ * Configuration properties for a Hotrod connection to a remote cache.
+ *
+ */
+public class InfinispanRemoteConfigurationProperties extends ConfigurationProperties {
+
+    private static final String DEFAULT_EXECUTOR_FACTORY_PREFIX = "infinispan.client.hotrod.default_executor_factory";
+    private static final String CONNECTION_POOL_PREFIX = "infinispan.client.hotrod.connection_pool";
+
+    /**
+     * Creates properties using default values.
+     */
+    public InfinispanRemoteConfigurationProperties() {
+        super();
+    }
+
+    /**
+     * Creates properties from existing options.
+     *
+     * @param options The options to copy.
+     */
+    @SuppressWarnings("deprecation")
+    public InfinispanRemoteConfigurationProperties(final InfinispanRemoteConfigurationOptions options) {
+        super();
+
+        options.authPassword().ifPresent(this::setAuthPassword);
+        options.authRealm().ifPresent(this::setAuthRealm);
+        options.authServerName().ifPresent(this::setAuthServerName);
+        options.authUsername().ifPresent(this::setAuthUsername);
+
+        setCluster(options.cluster());
+        setConnectionPool(options.connectionPool());
+        setConnectTimeout(options.connectTimeout());
+
+        setDefaultExecutorFactory(options.defaultExecutorFactory());
+
+        options.keyAlias().ifPresent(this::setKeyAlias);
+        options.keyStoreCertificatePassword().ifPresent(this::setKeyStoreCertificatePassword);
+        options.keyStoreFileName().ifPresent(this::setKeyStoreFileName);
+        options.keyStorePassword().ifPresent(this::setKeyStorePassword);
+        options.keyStoreType().ifPresent(this::setKeyStoreType);
+
+        options.saslMechanism().ifPresent(this::setSaslMechanism);
+        setSaslProperties(options.saslProperties());
+
+        options.serverList().ifPresent(this::setServerList);
+        setSocketTimeout(options.socketTimeout());
+
+        options.trustStoreFileName().ifPresent(this::setTrustStoreFileName);
+        options.trustStorePassword().ifPresent(this::setTrustStorePassword);
+        options.trustStorePath().ifPresent(this::setTrustStorePath);
+        options.trustStoreType().ifPresent(this::setTrustStoreType);
+
+        setUseSSL(options.useSsl());
+
+        options.sslCiphers().ifPresent(this::setSSLCiphers);
+        options.sslProtocol().ifPresent(this::setSSLProtocol);
+    }
+
+    /**
+     * Gets a builder for this configuration.
+     *
+     * @return A builder that can be used to create a cache.
+     */
+    public final ConfigurationBuilder getConfigurationBuilder() {
+       return new ConfigurationBuilder().withProperties(getProperties());
+    }
+
+    /**
+     * Sets the properties related to the connection pool.
+     * <p>
+     * Property keys may be in camel case or snake case.
+     *
+     * @param poolProperties The properties.
+     */
+    public final void setConnectionPool(final Map<String, String> poolProperties) {
+        setProperties(poolProperties, CONNECTION_POOL_PREFIX, this::toSnakeCase);
+    }
+
+    /**
+     * Sets the properties related to the default executor factory.
+     * <p>
+     * Property keys may be in camel case or snake case.
+     *
+     * @param factoryProperties The properties.
+     */
+    public final void setDefaultExecutorFactory(final Map<String, String> factoryProperties) {
+        setProperties(factoryProperties, DEFAULT_EXECUTOR_FACTORY_PREFIX, this::toSnakeCase);
+    }
+
+    /**
+     * Sets the properties related to the SASL based authentication.
+     *
+     * @param saslProperties The properties.
+     */
+    public final void setSaslProperties(final Map<String, String> saslProperties) {
+        setProperties(saslProperties, SASL_PROPERTIES_PREFIX, null);
+    }
+
+    /**
+     * Sets the properties related to cluster configuration.
+     *
+     * @param clusterProperties The properties.
+     */
+    public final void setCluster(final Map<String, String> clusterProperties) {
+        setProperties(clusterProperties, CLUSTER_PROPERTIES_PREFIX, null);
+    }
+
+    private String toSnakeCase(final String key) {
+        return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, key);
+    }
+
+    private void setProperties(
+            final Map<String, String> properties,
+            final String keyPrefix,
+            final Function<String, String> keyConverter) {
+
+        properties.forEach((k, v) -> {
+            final String keySuffix = Optional.ofNullable(keyConverter).map(f -> f.apply(k)).orElse(k);
+            final String key = String.format("%s.%s", keyPrefix, keySuffix);
+            getProperties().setProperty(key, v);
+        });
+    }
+
+    // ------- Getters/setters missing in the parent ConfigurationProperties class -------
+
+    /**
+     * Gets the keystore certificate password.
+     *
+     * @return The password.
+     */
+    public String getKeyStoreCertificatePassword() {
+        return getProperties().getProperty(KEY_STORE_CERTIFICATE_PASSWORD);
+    }
+
+    /**
+     * Gets the SSL ciphers.
+     *
+     * @return The ciphers.
+     */
+    public String getSSLCiphers() {
+        return getProperties().getProperty(SSL_CIPHERS);
+    }
+
+    /**
+     * Sets the SSL ciphers.
+     *
+     * @param ciphers The ciphers.
+     */
+    public void setSSLCiphers(final String ciphers) {
+        getProperties().put(SSL_CIPHERS, ciphers);
+    }
+
+   @Override
+   public String toString() {
+       return MoreObjects
+               .toStringHelper(this)
+               .add("serverList", this.getServerList())
+               .add("authUsername", this.getAuthUsername())
+               .toString();
+   }
+}

--- a/caches/cache-redis/pom.xml
+++ b/caches/cache-redis/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-caches-parent</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>hono-cache-redis</artifactId>
+
+    <name>Hono Client Device Connection Cache (Redis)</name>
+    <description>Redis implementation of Hono's Client Device Connection cache</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-cache-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+
+
+        <!-- testing -->
+        <!--
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+-->
+    </dependencies>
+</project>

--- a/caches/cache-redis/src/main/java/org/eclipse/hono/deviceconnection/redis/RedisCache.java
+++ b/caches/cache-redis/src/main/java/org/eclipse/hono/deviceconnection/redis/RedisCache.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection.redis;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.hono.cache.Cache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+/**
+ * TODO.
+ * @param <K> TODO
+ * @param <V> TODO
+ */
+public class RedisCache<K, V> implements Cache<K, V> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisCache.class);
+
+    private JedisPool pool;
+
+    /**
+     * TODO.
+     */
+    public RedisCache() {
+        LOG.info("Initializing REDIS cache!");
+        try {
+            pool = new JedisPool("redis", 6379);
+            try (Jedis jedis = pool.getResource()) {
+                final var response = jedis.ping();
+                LOG.info("Got {} from redis server", response);
+            }
+        } catch (Exception e) {
+            LOG.error("something went wrong", e);
+        }
+    }
+
+    @Override
+    public Future<JsonObject> checkForCacheAvailability() {
+        LOG.info("REDIS: checking for cache availability");
+        try (Jedis jedis = pool.getResource()) {
+            final var response = jedis.ping();
+            LOG.info("Got {} from redis server", response);
+            return Future.succeededFuture(new JsonObject());
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Void> put(final K key, final V value) {
+        LOG.info("REDIS: put {}={}", key, value);
+        try (Jedis jedis = pool.getResource()) {
+            jedis.set(key.toString(), value.toString());
+        }
+        return Future.succeededFuture();
+    }
+
+    @Override
+    public Future<Void> put(final K key, final V value, final long lifespan, final TimeUnit lifespanUnit) {
+        LOG.info("REDIS: put {}={} ({} {})", key, value, lifespan, lifespanUnit);
+        try (Jedis jedis = pool.getResource()) {
+            jedis.psetex(key.toString(), lifespanUnit.toMillis(lifespan), value.toString());
+            return Future.succeededFuture();
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Void> putAll(final Map<? extends K, ? extends V> data) {
+        LOG.info("REDIS: putAll ({})", data.size());
+        try (Jedis jedis = pool.getResource()) {
+            for (K k : data.keySet()) {
+                jedis.set(k.toString(), data.get(k).toString());
+            }
+            return Future.succeededFuture();
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Void> putAll(final Map<? extends K, ? extends V> data, final long lifespan, final TimeUnit lifespanUnit) {
+        LOG.info("REDIS: putAll ({}) ({} {})", data.size(), lifespan, lifespanUnit);
+        try (Jedis jedis = pool.getResource()) {
+            for (K k : data.keySet()) {
+                jedis.psetex(k.toString(), lifespanUnit.toMillis(lifespan), data.get(k).toString());
+            }
+            return Future.succeededFuture();
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<V> get(final K key) {
+        LOG.info("REDIS: get {}", key);
+        try (Jedis jedis = pool.getResource()) {
+            return Future.succeededFuture((V) jedis.get(key.toString()));
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Boolean> remove(final K key, final V value) {
+        LOG.info("REDIS: remove {}={}", key, value);
+        try (Jedis jedis = pool.getResource()) {
+            jedis.del(key.toString());
+            return Future.succeededFuture(true);
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+
+    @Override
+    public Future<Map<K, V>> getAll(final Set<? extends K> keys) {
+        LOG.warn("getAll() ({}) called but that has not been implemented!!!", keys.size());
+        try (Jedis jedis = pool.getResource()) {
+            return Future.succeededFuture(null);
+        } catch (Exception e) {
+            return Future.failedFuture(e);
+        }
+    }
+}

--- a/caches/pom.xml
+++ b/caches/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+   
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+   
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+   
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-bom</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+        <relativePath>../bom</relativePath>
+    </parent>
+
+    <artifactId>hono-caches-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hono Caches</name>
+    <description>Cache implementations used for Hono's client device connection (TODO: improve)</description>
+
+    <modules>
+        <module>cache-common</module>
+        <module>cache-infinispan</module>
+        <module>cache-redis</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-legal</artifactId>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>core-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>4.3.1</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-core</artifactId>
       <optional>true</optional>

--- a/client-device-connection/pom.xml
+++ b/client-device-connection/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0
+
+    SPDX-License-Identifier: EPL-2.0
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.hono</groupId>
+        <artifactId>hono-bom</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+        <relativePath>../bom</relativePath>
+    </parent>
+    <artifactId>hono-client-device-connection</artifactId>
+
+    <name>Hono Client Device Connection Cache</name>
+    <description>Common classes for Hono's Client Device Connection cache</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-client-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.hono</groupId>
+            <artifactId>hono-cache-common</artifactId>
+        </dependency>
+        <!--
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-health-check</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-auth-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+-->
+        <!-- testing -->
+        <!--
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+-->
+    </dependencies>
+</project>

--- a/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/AdapterInstanceStatusProvider.java
+++ b/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/AdapterInstanceStatusProvider.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.deviceconnection;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.eclipse.hono.util.AdapterInstanceStatus;
+
+import io.vertx.core.Future;
+
+/**
+ * Provides the status of an adapter instance.
+ */
+public interface AdapterInstanceStatusProvider {
+
+    /**
+     * Gets the status of the adapter identified by the given identifier.
+     *
+     * @param adapterInstanceId The identifier of the adapter instance.
+     * @return The status of the adapter instance.
+     * @throws NullPointerException if adapterInstanceId is {@code null}.
+     */
+    AdapterInstanceStatus getStatus(String adapterInstanceId);
+
+    /**
+     * Gets the identifiers of the adapter instances from the given collection
+     * that have the {@link AdapterInstanceStatus#DEAD} status.
+     * <p>
+     * Compared to {@link #getStatus(String)}, extra measures may be taken here
+     * to resolve the status of adapter instances otherwise classified as
+     * {@link AdapterInstanceStatus#SUSPECTED_DEAD} before completing the result future.
+     *
+     * @param adapterInstanceIds The identifiers of the adapter instances.
+     * @return A succeeded future containing the identifiers of the dead adapter instances or a failed future
+     *         indicating the reason why the operation failed.
+     * @throws NullPointerException if adapterInstanceIds is {@code null}.
+     */
+    Future<Set<String>> getDeadAdapterInstances(Collection<String> adapterInstanceIds);
+}

--- a/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/CacheBasedDeviceConnectionInfo.java
+++ b/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/CacheBasedDeviceConnectionInfo.java
@@ -1,0 +1,694 @@
+/**
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection;
+
+import java.net.HttpURLConnection;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.eclipse.hono.cache.Cache;
+import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.client.ServerErrorException;
+import org.eclipse.hono.client.util.ServiceClient;
+import org.eclipse.hono.tracing.TracingHelper;
+import org.eclipse.hono.util.AdapterInstanceStatus;
+import org.eclipse.hono.util.DeviceConnectionConstants;
+import org.eclipse.hono.util.Lifecycle;
+import org.eclipse.hono.util.MessageHelper;
+import org.eclipse.hono.util.RequestResponseApiConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.healthchecks.HealthCheckHandler;
+import io.vertx.ext.healthchecks.Status;
+
+
+/**
+ * A client for accessing device connection information in a data grid.
+ */
+public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInfo, ServiceClient, Lifecycle {
+
+    /**
+     * Lifespan for last-known-gateway cache entries.
+     */
+    static final Duration LAST_KNOWN_GATEWAY_CACHE_ENTRY_LIFESPAN = Duration.ofDays(28);
+
+    /**
+     * For <em>viaGateways</em> parameter value lower or equal to this value, the {@link #getCommandHandlingAdapterInstances(String, String, Set, Span)}
+     * method will use an optimized approach, potentially saving additional cache requests.
+     */
+    static final int VIA_GATEWAYS_OPTIMIZATION_THRESHOLD = 3;
+
+    private static final Logger LOG = LoggerFactory.getLogger(CacheBasedDeviceConnectionInfo.class);
+
+    /**
+     * Key prefix for cache entries having gateway id values, concerning <em>lastKnownGatewayForDevice</em>
+     * operations.
+     */
+    private static final String KEY_PREFIX_GATEWAY_ENTRIES_VALUE = "gw";
+    /**
+     * Key prefix for cache entries having protocol adapter instance id values, concerning
+     * <em>commandHandlingAdapterInstance</em> operations.
+     */
+    private static final String KEY_PREFIX_ADAPTER_INSTANCE_VALUES = "ai";
+    private static final String KEY_SEPARATOR = "@@";
+
+    final Cache<String, String> cache;
+    final Tracer tracer;
+    final AdapterInstanceStatusProvider adapterInstanceStatusProvider;
+
+    private DeviceToAdapterMappingErrorListener deviceToAdapterMappingErrorListener;
+
+    /**
+     * Creates a client for accessing device connection information.
+     *
+     * @param cache The remote cache that contains the data.
+     * @param tracer The tracer instance.
+     * @throws NullPointerException if cache or tracer is {@code null}.
+     */
+    public CacheBasedDeviceConnectionInfo(final Cache<String, String> cache, final Tracer tracer) {
+        this(cache, tracer, null);
+    }
+
+    /**
+     * Creates a client for accessing device connection information.
+     *
+     * @param cache The remote cache that contains the data.
+     * @param tracer The tracer instance.
+     * @param adapterInstanceStatusProvider The provider of the adapter instance status (may be {@code null}).
+     * @throws NullPointerException if cache or tracer is {@code null}.
+     */
+    public CacheBasedDeviceConnectionInfo(final Cache<String, String> cache, final Tracer tracer,
+                                          final AdapterInstanceStatusProvider adapterInstanceStatusProvider) {
+        this.cache = Objects.requireNonNull(cache);
+        this.tracer = Objects.requireNonNull(tracer);
+        this.adapterInstanceStatusProvider = Optional.ofNullable(adapterInstanceStatusProvider)
+                .orElseGet(UnknownStatusProvider::new);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * If this method is invoked from a vert.x Context, then the returned future will be completed on that context.
+     */
+    @Override
+    public Future<Void> setLastKnownGatewayForDevice(
+            final String tenantId,
+            final String deviceId,
+            final String gatewayId,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(gatewayId);
+        Objects.requireNonNull(span);
+
+        final long lifespanMillis = LAST_KNOWN_GATEWAY_CACHE_ENTRY_LIFESPAN.toMillis();
+        return cache.put(getGatewayEntryKey(tenantId, deviceId), gatewayId, lifespanMillis, TimeUnit.MILLISECONDS)
+            .onSuccess(ok -> LOG.debug("set last known gateway [tenant: {}, device-id: {}, gateway: {}]",
+                    tenantId, deviceId, gatewayId))
+            .otherwise(t -> {
+                LOG.debug("failed to set last known gateway [tenant: {}, device-id: {}, gateway: {}]",
+                        tenantId, deviceId, gatewayId, t);
+                TracingHelper.logError(span, "failed to set last known gateway", t);
+                throw new ServerErrorException(tenantId, HttpURLConnection.HTTP_INTERNAL_ERROR, t);
+            });
+    }
+
+    @Override
+    public Future<Void> setLastKnownGatewayForDevice(
+            final String tenantId,
+            final Map<String, String> deviceIdToGatewayIdMap,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceIdToGatewayIdMap);
+        Objects.requireNonNull(span);
+
+        if (deviceIdToGatewayIdMap.isEmpty()) {
+            return Future.succeededFuture();
+        }
+
+        final long lifespanMillis = LAST_KNOWN_GATEWAY_CACHE_ENTRY_LIFESPAN.toMillis();
+        final Map<String, String> mapToBePut = deviceIdToGatewayIdMap.entrySet().stream()
+                .collect(Collectors.toMap(entry -> getGatewayEntryKey(tenantId, entry.getKey()), Map.Entry::getValue));
+        return cache.putAll(mapToBePut, lifespanMillis, TimeUnit.MILLISECONDS)
+                .onSuccess(ok -> LOG.debug("set {} last known gateway entries [tenant: {}]",
+                        deviceIdToGatewayIdMap.size(), tenantId))
+                .otherwise(t -> {
+                    LOG.debug("failed to set {} last known gateway entries [tenant: {}]",
+                            deviceIdToGatewayIdMap.size(), tenantId, t);
+                    TracingHelper.logError(span, "failed to set last known gateway entries", t);
+                    throw new ServerErrorException(tenantId, HttpURLConnection.HTTP_INTERNAL_ERROR, t);
+                });
+    }
+
+    @Override
+    public Future<JsonObject> getLastKnownGatewayForDevice(
+            final String tenantId,
+            final String deviceId,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(span);
+
+        return cache.get(getGatewayEntryKey(tenantId, deviceId))
+                .otherwise(t -> {
+                    LOG.debug("failed to find last known gateway for device [tenant: {}, device-id: {}]",
+                            tenantId, deviceId, t);
+                    TracingHelper.logError(span, "failed to find last known gateway for device", t);
+                    throw new ServerErrorException(tenantId, HttpURLConnection.HTTP_INTERNAL_ERROR, t);
+                })
+                .compose(gatewayId -> {
+                    if (gatewayId == null) {
+                        LOG.debug("could not find last known gateway for device [tenant: {}, device-id: {}]", tenantId,
+                                deviceId);
+                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    } else {
+                        LOG.debug("found last known gateway for device [tenant: {}, device-id: {}]: {}", tenantId,
+                                deviceId, gatewayId);
+                        return Future.succeededFuture(getLastKnownGatewayResultJson(gatewayId));
+                    }
+                });
+    }
+
+    @Override
+    public Future<Void> setCommandHandlingAdapterInstance(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final Duration lifespan,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(adapterInstanceId);
+        Objects.requireNonNull(span);
+
+        // sanity check, preventing an ArithmeticException in lifespan.toMillis()
+        final long lifespanMillis = lifespan == null || lifespan.isNegative()
+                || lifespan.getSeconds() > (Long.MAX_VALUE / 1000L) ? -1 : lifespan.toMillis();
+        return cache.put(getAdapterInstanceEntryKey(tenantId, deviceId), adapterInstanceId, lifespanMillis, TimeUnit.MILLISECONDS)
+                .onSuccess(ok -> LOG.debug(
+                        "set command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}, lifespan: {}ms]",
+                        tenantId, deviceId, adapterInstanceId, lifespanMillis))
+                .otherwise(t -> {
+                    LOG.debug("failed to set command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}, lifespan: {}ms]",
+                            tenantId, deviceId, adapterInstanceId, lifespanMillis, t);
+                    TracingHelper.logError(span, "failed to set command handling adapter instance cache entry", t);
+                    throw new ServerErrorException(tenantId, HttpURLConnection.HTTP_INTERNAL_ERROR, t);
+                });
+    }
+
+    @Override
+    public Future<Void> removeCommandHandlingAdapterInstance(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(adapterInstanceId);
+        Objects.requireNonNull(span);
+
+        return cache
+                .remove(getAdapterInstanceEntryKey(tenantId, deviceId), adapterInstanceId)
+                .otherwise(t -> {
+                    LOG.debug("failed to remove the cache entry for the command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
+                            tenantId, deviceId, adapterInstanceId, t);
+                    TracingHelper.logError(span, "failed to remove cache entry for the command handling adapter instance", t);
+                    throw new ServerErrorException(tenantId, HttpURLConnection.HTTP_INTERNAL_ERROR, t);
+                })
+                .compose(removed -> {
+                    if (!removed) {
+                        LOG.debug("command handling adapter instance was not removed, key not mapped or value didn't match [tenant: {}, device-id: {}, adapter-instance: {}]",
+                                tenantId, deviceId, adapterInstanceId);
+                        return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_PRECON_FAILED));
+                    } else {
+                        LOG.debug("removed command handling adapter instance [tenant: {}, device-id: {}, adapter-instance: {}]",
+                                tenantId, deviceId, adapterInstanceId);
+                        return Future.succeededFuture();
+                    }
+                });
+
+    }
+
+    @Override
+    public Future<JsonObject> getCommandHandlingAdapterInstances(
+            final String tenantId,
+            final String deviceId,
+            final Set<String> viaGateways,
+            final Span span) {
+
+        Objects.requireNonNull(tenantId);
+        Objects.requireNonNull(deviceId);
+        Objects.requireNonNull(viaGateways);
+        Objects.requireNonNull(span);
+
+        final Future<JsonObject> resultFuture;
+        if (viaGateways.isEmpty()) {
+            // get the command handling adapter instance for the device (no gateway involved)
+            resultFuture = cache.get(getAdapterInstanceEntryKey(tenantId, deviceId))
+                    .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t, span))
+                    .compose(adapterInstanceId -> checkAdapterInstanceId(adapterInstanceId, tenantId, deviceId, span))
+                    .compose(adapterInstanceId -> {
+                        if (adapterInstanceId == null) {
+                            LOG.debug("no command handling adapter instances found [tenant: {}, device-id: {}]",
+                                    tenantId, deviceId);
+                            span.log("no command handling adapter instances found for device (no via-gateways given)");
+                            return Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                        } else {
+                            LOG.debug("found command handling adapter instance '{}' [tenant: {}, device-id: {}]",
+                                    adapterInstanceId, tenantId, deviceId);
+                            span.log("returning command handling adapter instance for device itself");
+                            setTagsForSingleResult(span, adapterInstanceId);
+                            return Future.succeededFuture(getAdapterInstancesResultJson(deviceId, adapterInstanceId));
+                        }
+                    });
+        } else if (viaGateways.size() <= VIA_GATEWAYS_OPTIMIZATION_THRESHOLD) {
+            resultFuture = getInstancesQueryingAllGatewaysFirst(tenantId, deviceId, viaGateways, span);
+        } else {
+            // number of viaGateways is more than threshold value - reduce cache accesses by not checking *all* viaGateways,
+            // instead trying the last known gateway first
+            resultFuture = getInstancesGettingLastKnownGatewayFirst(tenantId, deviceId, viaGateways, span);
+        }
+        return resultFuture;
+    }
+
+    @Override
+    public void setDeviceToAdapterMappingErrorListener(
+            final DeviceToAdapterMappingErrorListener obsoleteMappingListener) {
+        this.deviceToAdapterMappingErrorListener = obsoleteMappingListener;
+    }
+
+    private Future<JsonObject> getInstancesQueryingAllGatewaysFirst(
+            final String tenantId,
+            final String deviceId,
+            final Set<String> viaGateways,
+            final Span span) {
+
+        LOG.debug("using optimized query, retrieving {} via-gateways in one go", viaGateways.size());
+        // get the command handling adapter instances for the device and *all* via-gateways in one call first
+        // (this saves the extra lastKnownGateway check if only one adapter instance is returned)
+        return cache.getAll(getAdapterInstanceEntryKeys(tenantId, deviceId, viaGateways))
+                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t, span))
+                .compose(getAllMap -> checkAdapterInstanceIds(tenantId, convertAdapterInstanceEntryKeys(getAllMap), span))
+                .compose(deviceToInstanceMap -> {
+                    final Future<JsonObject> resultFuture;
+                    if (deviceToInstanceMap.isEmpty()) {
+                        LOG.debug("no command handling adapter instances found [tenant: {}, device-id: {}]",
+                                tenantId, deviceId);
+                        span.log("no command handling adapter instances found for device or given via-gateways ("
+                                + String.join(", ", viaGateways) + ")");
+                        resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    } else if (deviceToInstanceMap.containsKey(deviceId)) {
+                        // there is a adapter instance set for the device itself - that gets precedence
+                        resultFuture = getAdapterInstanceFoundForDeviceItselfResult(tenantId, deviceId,
+                                deviceToInstanceMap.get(deviceId), span);
+                    } else if (deviceToInstanceMap.size() > 1) {
+                        // multiple gateways found - check last known gateway
+                        resultFuture = cache.get(getGatewayEntryKey(tenantId, deviceId))
+                                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t, span))
+                                .compose(lastKnownGateway -> {
+                                    if (lastKnownGateway == null) {
+                                        // no last known gateway found - just return all found mapping entries
+                                        LOG.debug("returning {} command handling adapter instances for device gateways (no last known gateway found) [tenant: {}, device-id: {}]",
+                                                deviceToInstanceMap.size(), tenantId, deviceId);
+                                        span.log("no last known gateway found, returning all matching adapter instances");
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    } else if (!viaGateways.contains(lastKnownGateway)) {
+                                        // found gateway is not valid anymore - just return all found mapping entries
+                                        LOG.debug("returning {} command handling adapter instances for device gateways (last known gateway not valid anymore) [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.size(), tenantId, deviceId, lastKnownGateway);
+                                        span.log(String.format(
+                                                "last known gateway '%s' is not valid anymore, returning all matching adapter instances",
+                                                lastKnownGateway));
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    } else if (!deviceToInstanceMap.containsKey(lastKnownGateway)) {
+                                        // found gateway has no command handling instance assigned - just return all found mapping entries
+                                        LOG.debug("returning {} command handling adapter instances for device gateways (last known gateway not in that list) [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.size(), tenantId, deviceId, lastKnownGateway);
+                                        span.log(String.format(
+                                                "last known gateway '%s' has no adapter instance assigned, returning all matching adapter instances",
+                                                lastKnownGateway));
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    } else {
+                                        LOG.debug("returning command handling adapter instance '{}' for last known gateway [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.get(lastKnownGateway), tenantId, deviceId, lastKnownGateway);
+                                        span.log("returning adapter instance for last known gateway '" + lastKnownGateway + "'");
+                                        setTagsForSingleResultWithGateway(span, deviceToInstanceMap.get(lastKnownGateway), lastKnownGateway);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(lastKnownGateway,
+                                                deviceToInstanceMap.get(lastKnownGateway)));
+                                    }
+                                });
+                    } else {
+                        // one command handling instance found
+                        final Map.Entry<String, String> foundEntry = deviceToInstanceMap.entrySet().iterator().next();
+                        LOG.debug("returning command handling adapter instance '{}' associated with gateway {} [tenant: {}, device-id: {}]",
+                                foundEntry.getValue(), foundEntry.getKey(), tenantId, deviceId);
+                        span.log("returning adapter instance associated with gateway '" + foundEntry.getKey() + "'");
+                        setTagsForSingleResultWithGateway(span, foundEntry.getValue(), foundEntry.getKey());
+                        resultFuture = Future.succeededFuture(getAdapterInstancesResultJson(foundEntry.getKey(),
+                                foundEntry.getValue()));
+                    }
+                    return resultFuture;
+                });
+    }
+
+    private void setTagsForSingleResultWithGateway(final Span span, final String adapterInstanceId, final String gatewayId) {
+        setTagsForSingleResult(span, adapterInstanceId);
+        span.setTag(MessageHelper.APP_PROPERTY_GATEWAY_ID, gatewayId);
+    }
+
+    private void setTagsForSingleResult(final Span span, final String adapterInstanceId) {
+        TracingHelper.TAG_ADAPTER_INSTANCE_ID.set(span, adapterInstanceId);
+    }
+
+    private Future<JsonObject> getInstancesGettingLastKnownGatewayFirst(
+            final String tenantId,
+            final String deviceId,
+            final Set<String> viaGateways,
+            final Span span) {
+
+        return cache.get(getGatewayEntryKey(tenantId, deviceId))
+                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t, span))
+                .compose(lastKnownGateway -> {
+                    if (lastKnownGateway == null) {
+                        LOG.trace("no last known gateway found [tenant: {}, device-id: {}]", tenantId, deviceId);
+                        span.log("no last known gateway found");
+                    } else if (!viaGateways.contains(lastKnownGateway)) {
+                        LOG.trace("found gateway is not valid for the device anymore [tenant: {}, device-id: {}]", tenantId, deviceId);
+                        span.log("found gateway '" + lastKnownGateway + "' is not valid anymore");
+                    }
+                    if (lastKnownGateway != null && viaGateways.contains(lastKnownGateway)) {
+                        // fetch command handling instances for lastKnownGateway and device
+                        return cache.getAll(getAdapterInstanceEntryKeys(tenantId, deviceId, lastKnownGateway))
+                                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t, span))
+                                .compose(getAllMap -> checkAdapterInstanceIds(tenantId, convertAdapterInstanceEntryKeys(getAllMap), span))
+                                .compose(deviceToInstanceMap -> {
+                                    if (deviceToInstanceMap.isEmpty()) {
+                                        // no adapter instances found for last-known-gateway and device - check all via gateways
+                                        span.log(String.format(
+                                                "last known gateway '%s' has no adapter instance assigned, returning all matching adapter instances",
+                                                lastKnownGateway));
+                                        return getAdapterInstancesWithoutLastKnownGatewayCheck(tenantId, deviceId, viaGateways, span);
+                                    } else if (deviceToInstanceMap.containsKey(deviceId)) {
+                                        // there is a adapter instance set for the device itself - that gets precedence
+                                        return getAdapterInstanceFoundForDeviceItselfResult(tenantId, deviceId, deviceToInstanceMap.get(deviceId), span);
+                                    } else {
+                                        // adapter instance found for last known gateway
+                                        LOG.debug("returning command handling adapter instance '{}' for last known gateway [tenant: {}, device-id: {}, lastKnownGateway: {}]",
+                                                deviceToInstanceMap.get(lastKnownGateway), tenantId, deviceId, lastKnownGateway);
+                                        span.log("returning adapter instance for last known gateway '" + lastKnownGateway + "'");
+                                        setTagsForSingleResultWithGateway(span, deviceToInstanceMap.get(lastKnownGateway), lastKnownGateway);
+                                        return Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                                    }
+                                });
+                    } else {
+                        // last-known-gateway not found or invalid - look for all adapter instances for device and viaGateways
+                        return getAdapterInstancesWithoutLastKnownGatewayCheck(tenantId, deviceId, viaGateways, span);
+                    }
+                });
+    }
+
+    private Future<JsonObject> getAdapterInstancesWithoutLastKnownGatewayCheck(
+            final String tenantId,
+            final String deviceId,
+            final Set<String> viaGateways,
+            final Span span) {
+
+        return cache.getAll(getAdapterInstanceEntryKeys(tenantId, deviceId, viaGateways))
+                .recover(t -> failedToGetEntriesWhenGettingInstances(tenantId, deviceId, t, span))
+                .compose(getAllMap -> checkAdapterInstanceIds(tenantId, convertAdapterInstanceEntryKeys(getAllMap), span))
+                .compose(deviceToInstanceMap -> {
+                    final Future<JsonObject> resultFuture;
+                    if (deviceToInstanceMap.isEmpty()) {
+                        LOG.debug("no command handling adapter instances found [tenant: {}, device-id: {}]",
+                                tenantId, deviceId);
+                        span.log("no command handling adapter instances found for device or given via-gateways ("
+                                + String.join(", ", viaGateways) + ")");
+                        resultFuture = Future.failedFuture(new ClientErrorException(HttpURLConnection.HTTP_NOT_FOUND));
+                    } else if (deviceToInstanceMap.containsKey(deviceId)) {
+                        // there is a command handling instance set for the device itself - that gets precedence
+                        resultFuture = getAdapterInstanceFoundForDeviceItselfResult(tenantId, deviceId, deviceToInstanceMap.get(deviceId), span);
+                    } else {
+                        LOG.debug("returning {} command handling adapter instance(s) (no last known gateway found) [tenant: {}, device-id: {}]",
+                                deviceToInstanceMap.size(), tenantId, deviceId);
+                        resultFuture = Future.succeededFuture(getAdapterInstancesResultJson(deviceToInstanceMap));
+                    }
+                    return resultFuture;
+                });
+    }
+
+    private Future<JsonObject> getAdapterInstanceFoundForDeviceItselfResult(
+            final String tenantId,
+            final String deviceId,
+            final String adapterInstanceId,
+            final Span span) {
+
+        LOG.debug("returning command handling adapter instance '{}' for device itself [tenant: {}, device-id: {}]",
+                adapterInstanceId, tenantId, deviceId);
+        span.log("returning command handling adapter instance for device itself");
+        setTagsForSingleResult(span, adapterInstanceId);
+        return Future.succeededFuture(getAdapterInstancesResultJson(deviceId, adapterInstanceId));
+    }
+
+    private <T> Future<T> failedToGetEntriesWhenGettingInstances(
+            final String tenantId,
+            final String deviceId,
+            final Throwable t,
+            final Span span) {
+
+        LOG.debug("failed to get cache entries when trying to get command handling adapter instances [tenant: {}, device-id: {}]",
+                tenantId, deviceId, t);
+        TracingHelper.logError(span, "failed to get cache entries when trying to get command handling adapter instances", t);
+        return Future.failedFuture(new ServerErrorException(HttpURLConnection.HTTP_INTERNAL_ERROR, t));
+    }
+
+    static String getGatewayEntryKey(final String tenantId, final String deviceId) {
+        return KEY_PREFIX_GATEWAY_ENTRIES_VALUE + KEY_SEPARATOR + tenantId + KEY_SEPARATOR + deviceId;
+    }
+
+    static String getAdapterInstanceEntryKey(final String tenantId, final String deviceId) {
+        return KEY_PREFIX_ADAPTER_INSTANCE_VALUES + KEY_SEPARATOR + tenantId + KEY_SEPARATOR + deviceId;
+    }
+
+    static Set<String> getAdapterInstanceEntryKeys(
+            final String tenantId,
+            final String deviceIdA,
+            final String deviceIdB) {
+
+        final Set<String> keys = new HashSet<>(2);
+        keys.add(getAdapterInstanceEntryKey(tenantId, deviceIdA));
+        keys.add(getAdapterInstanceEntryKey(tenantId, deviceIdB));
+        return keys;
+    }
+
+    /**
+     * Puts the entries from the given map, having {@link #getAdapterInstanceEntryKey(String, String)} keys, into
+     * a new map with just the extracted device ids as keys.
+     *
+     * @param map Map to get the entries from.
+     * @return New map with keys containing just the device id.
+     */
+    private static Map<String, String> convertAdapterInstanceEntryKeys(final Map<String, String> map) {
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(entry -> getDeviceIdFromAdapterInstanceEntryKey(
+                        entry.getKey()), Map.Entry::getValue));
+    }
+
+    private static String getDeviceIdFromAdapterInstanceEntryKey(final String key) {
+        final int pos = key.lastIndexOf(KEY_SEPARATOR);
+        return key.substring(pos + KEY_SEPARATOR.length());
+    }
+
+    static Set<String> getAdapterInstanceEntryKeys(
+            final String tenantId,
+            final String deviceIdA,
+            final Set<String> additionalDeviceIds) {
+
+        final Set<String> keys = new HashSet<>(additionalDeviceIds.size() + 1);
+        keys.add(getAdapterInstanceEntryKey(tenantId, deviceIdA));
+        additionalDeviceIds.forEach(id -> keys.add(getAdapterInstanceEntryKey(tenantId, id)));
+        return keys;
+    }
+
+    private static JsonObject getLastKnownGatewayResultJson(final String gatewayId) {
+        return new JsonObject().put(DeviceConnectionConstants.FIELD_GATEWAY_ID, gatewayId);
+    }
+
+    private static JsonObject getAdapterInstancesResultJson(final Map<String, String> deviceToAdapterInstanceMap) {
+        final JsonObject jsonObject = new JsonObject();
+        final JsonArray adapterInstancesArray = new JsonArray(new ArrayList<>(deviceToAdapterInstanceMap.size()));
+        for (final Map.Entry<String, String> resultEntry : deviceToAdapterInstanceMap.entrySet()) {
+            final JsonObject entryJson = new JsonObject();
+            entryJson.put(RequestResponseApiConstants.FIELD_PAYLOAD_DEVICE_ID, resultEntry.getKey());
+            entryJson.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCE_ID, resultEntry.getValue());
+            adapterInstancesArray.add(entryJson);
+        }
+        jsonObject.put(DeviceConnectionConstants.FIELD_ADAPTER_INSTANCES, adapterInstancesArray);
+        return jsonObject;
+    }
+
+    private static JsonObject getAdapterInstancesResultJson(final String deviceId, final String adapterInstanceId) {
+        return getAdapterInstancesResultJson(Map.of(deviceId, adapterInstanceId));
+    }
+
+    private Future<Map<String, String>> checkAdapterInstanceIds(final String tenantId,
+            final Map<String, String> deviceToInstanceIdMap, final Span span) {
+
+        @SuppressWarnings("rawtypes")
+        final List<Future> mappingFutures = new ArrayList<>();
+        final Map<String, String> deviceToInstanceIdMapResult = new HashMap<>();
+        deviceToInstanceIdMap.entrySet().forEach(entry -> {
+            final Future<String> mappingFuture = checkAdapterInstanceId(entry.getValue(), tenantId, entry.getKey(), span)
+                    .map(adapterId -> {
+                        if (adapterId != null) {
+                            deviceToInstanceIdMapResult.put(entry.getKey(), entry.getValue());
+                        }
+                        return adapterId;
+                    });
+            mappingFutures.add(mappingFuture);
+        });
+
+        return CompositeFuture.join(mappingFutures).map(deviceToInstanceIdMapResult);
+    }
+
+    private Future<String> checkAdapterInstanceId(
+            final String adapterInstanceId,
+            final String tenantId,
+            final String deviceId,
+            final Span span) {
+
+        if (adapterInstanceId != null) {
+            final AdapterInstanceStatus status = adapterInstanceStatusProvider.getStatus(adapterInstanceId);
+            if (status == AdapterInstanceStatus.DEAD) {
+                LOG.debug(
+                        "ignoring found adapter instance id, belongs to already terminated container [tenant: {}, device-id: {}, adapter-instance-id: {}]",
+                        tenantId, deviceId, adapterInstanceId);
+                span.log("ignoring found adapter instance id [" + adapterInstanceId
+                        + "], belongs to already terminated container");
+                final Future<Void> listenerResult;
+                if (deviceToAdapterMappingErrorListener != null) {
+                    listenerResult = deviceToAdapterMappingErrorListener.onObsoleteEntryFound(tenantId, deviceId,
+                            adapterInstanceId,
+                            span);
+                } else {
+                    listenerResult = Future.succeededFuture();
+                }
+                return listenerResult
+                        .onSuccess(v -> {
+                            if (deviceToAdapterMappingErrorListener != null) {
+                                LOG.debug(
+                                        "called listener for obsolete adapter instance id '{}' [tenant: {}, device-id: {}]",
+                                        adapterInstanceId, tenantId, deviceId);
+                            }
+                        })
+                        .onFailure(thr -> {
+                            LOG.debug(
+                                    "error calling listener for obsolete adapter instance id '{}' [tenant: {}, device-id: {}]",
+                                    adapterInstanceId, tenantId, deviceId, thr);
+                        })
+                        .compose(s -> {
+                            return cache.remove(getAdapterInstanceEntryKey(tenantId, deviceId), adapterInstanceId)
+                                    .onSuccess(removed -> {
+                                        if (removed) {
+                                            LOG.debug(
+                                                    "removed entry with obsolete adapter instance id '{}' [tenant: {}, device-id: {}]",
+                                                    adapterInstanceId, tenantId, deviceId);
+                                        }
+                                    })
+                                    .onFailure(thr -> {
+                                        LOG.debug(
+                                                "error removing entry with obsolete adapter instance id '{}' [tenant: {}, device-id: {}]",
+                                                adapterInstanceId, tenantId, deviceId, thr);
+                                    });
+                        })
+                        .recover(thr -> {
+                            // errors treated as not found adapter instance
+                            return Future.succeededFuture();
+                        })
+                        .mapEmpty();
+            } else if (status == AdapterInstanceStatus.SUSPECTED_DEAD) {
+                LOG.debug(
+                        "ignoring found adapter instance id, belongs to container with state 'SUSPECTED_DEAD' [tenant: {}, device-id: {}, adapter-instance-id: {}]",
+                        tenantId, deviceId, adapterInstanceId);
+                span.log("ignoring found adapter instance id [" + adapterInstanceId +
+                        "], belongs to container with state 'SUSPECTED_DEAD'");
+                return Future.succeededFuture();
+            }
+        }
+        return Future.succeededFuture(adapterInstanceId);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Registers a check which verifies if the underlying cache is available.
+     * The check times out (and fails) after 1000ms.
+     */
+    @Override
+    public void registerReadinessChecks(final HealthCheckHandler readinessHandler) {
+        readinessHandler.register("remote-cache-connection", 1000, this::checkForCacheAvailability);
+    }
+
+    private void checkForCacheAvailability(final Promise<Status> status) {
+
+        cache.checkForCacheAvailability()
+            .map(Status::OK)
+            .otherwise(t -> Status.KO())
+            .onComplete(ar -> status.tryComplete(ar.result()));
+    }
+
+    @Override
+    public void registerLivenessChecks(final HealthCheckHandler livenessHandler) {
+        // nothing to register
+    }
+
+    @Override
+    public Future<Void> start() {
+        if (cache instanceof Lifecycle) {
+            return ((Lifecycle) cache).start();
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+
+    @Override
+    public Future<Void> stop() {
+        if (cache instanceof Lifecycle) {
+            return ((Lifecycle) cache).stop();
+        } else {
+            return Future.succeededFuture();
+        }
+    }
+}

--- a/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/DeviceConnectionInfo.java
+++ b/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/DeviceConnectionInfo.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * A repository for keeping connection information about devices.
+ *
+ */
+public interface DeviceConnectionInfo {
+
+    /**
+     * Sets the gateway that last acted on behalf of a device.
+     * <p>
+     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as value
+     * for the <em>gatewayId</em> parameter.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param gatewayId The gateway identifier. This may be the same as the device identifier if the device is
+     *                  (currently) not connected via a gateway but directly to a protocol adapter.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the device connection information has been updated.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> setLastKnownGatewayForDevice(String tenant, String deviceId, String gatewayId, Span span);
+
+    /**
+     * For a given list of device and gateway combinations, sets the gateway as the last gateway that acted on behalf
+     * of the device.
+     * <p>
+     * If a device connects directly instead of through a gateway, the device identifier itself is to be used as
+     * gateway value.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceIdToGatewayIdMap The map containing device identifiers and associated gateway identifiers. The
+     *                               gateway identifier may be the same as the device identifier if the device is
+     *                               (currently) not connected via a gateway but directly to a protocol adapter.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the device connection information has been updated.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     *         The outcome is indeterminate if any of the entries cannot be processed by an implementation.
+     *         In such a case, client code should assume that none of the entries have been updated.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<Void> setLastKnownGatewayForDevice(String tenant, Map<String, String> deviceIdToGatewayIdMap, Span span);
+
+    /**
+     * Gets the gateway that last acted on behalf of a device.
+     * <p>
+     * If no last known gateway has been set for the given device yet, a failed future with status
+     * <em>404</em> is returned.
+     *
+     * @param tenant The tenant that the device belongs to.
+     * @param deviceId The device identifier.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded with a JSON object containing the currently mapped gateway ID
+     *         in the <em>gateway-id</em> property, if device connection information has been found for
+     *         the given device.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<JsonObject> getLastKnownGatewayForDevice(String tenant, String deviceId, Span span);
+
+    /**
+     * Sets the protocol adapter instance that handles commands for the given device or gateway.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id.
+     * @param lifespan The lifespan of the mapping entry. Using a negative duration or {@code null} here is
+     *                 interpreted as an unlimited lifespan.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the device connection information has been updated.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except lifespan is {@code null}.
+     */
+    Future<Void> setCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId,
+            Duration lifespan, Span span);
+
+    /**
+     * Removes the mapping information that associates the given device with the given protocol adapter instance
+     * that handles commands for the given device. The mapping entry is only deleted if its value
+     * contains the given protocol adapter instance id.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param adapterInstanceId The protocol adapter instance id that the entry to be removed has to contain.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         The future will be succeeded if the entry was successfully removed.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters except context is {@code null}.
+     */
+    Future<Void> removeCommandHandlingAdapterInstance(String tenantId, String deviceId, String adapterInstanceId, Span span);
+
+    /**
+     * Gets information about the adapter instances that can handle a command for the given device.
+     * <p>
+     * In order to determine the adapter instances the following rules are applied (in the given order):
+     * <ol>
+     * <li>If an adapter instance is associated with the given device, this adapter instance is returned as the single
+     * returned list entry.</li>
+     * <li>Otherwise, if there is an adapter instance registered for the last known gateway associated with the given
+     * device, this adapter instance is returned as the single returned list entry. The last known gateway has to be
+     * contained in the given list of gateways for this case.</li>
+     * <li>Otherwise, all adapter instances associated with any of the given gateway identifiers are returned.</li>
+     * </ol>
+     * That means that for a device communicating via a gateway, the result is reduced to a <i>single element</i> list
+     * if an adapter instance for the device itself or its last known gateway is found. The adapter instance registered
+     * for the device itself is given precedence in order to ensure that a gateway having subscribed to commands for
+     * that particular device is chosen over a gateway that has subscribed to commands for all devices of a tenant.
+     * <p>
+     * The resulting JSON structure looks like this, possibly containing multiple array entries: <code>
+     * {
+     *   "adapter-instances": [
+     *     {
+     *       "adapter-instance-id": "adapter-1",
+     *       "device-id": "4711"
+     *     }
+     *   ]
+     * }
+     * </code>
+     * <p>
+     * If no adapter instances are found, the returned future is failed.
+     *
+     * @param tenantId The tenant id.
+     * @param deviceId The device id.
+     * @param viaGateways The set of gateways that may act on behalf of the given device.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method!
+     *            An implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation.
+     *         <p>
+     *         If instances were found, the future will be succeeded with a JSON object containing one or more mappings
+     *         from device id to adapter instance id.
+     *         Otherwise the future will be failed with a {@link org.eclipse.hono.client.ServiceInvocationException}.
+     * @throws NullPointerException if any of the parameters is {@code null}.
+     */
+    Future<JsonObject> getCommandHandlingAdapterInstances(String tenantId, String deviceId, Set<String> viaGateways, Span span);
+
+    /**
+     * Sets listener to be notified when an incorrect device to adapter mapping is identified.
+     *
+     * @param deviceToAdapterMappingErrorListener The listener.
+     */
+    void setDeviceToAdapterMappingErrorListener(DeviceToAdapterMappingErrorListener deviceToAdapterMappingErrorListener);
+}

--- a/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/DeviceToAdapterMappingErrorListener.java
+++ b/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/DeviceToAdapterMappingErrorListener.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.hono.deviceconnection;
+
+import io.opentracing.Span;
+import io.vertx.core.Future;
+
+/**
+ * Listener notified when an incorrect device to adapter mapping is found.
+ */
+public interface DeviceToAdapterMappingErrorListener {
+
+    /**
+     * Called when an obsolete device to adapter mapping is found.
+     *
+     * @param tenantId The tenant identifier.
+     * @param deviceId The device identifier.
+     * @param adapterInstanceId The adapter instance identifier.
+     * @param span The active OpenTracing span for this operation. It is not to be closed in this method! An
+     *            implementation should log (error) events on this span and it may set tags and use this span as the
+     *            parent for any spans created in this method.
+     * @return A future indicating the outcome of the operation. The future will be succeeded if the listener is
+     *         notified successfully.
+     */
+    Future<Void> onObsoleteEntryFound(String tenantId, String deviceId, String adapterInstanceId, Span span);
+}

--- a/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/UnknownStatusProvider.java
+++ b/client-device-connection/src/main/java/org/eclipse/hono/deviceconnection/UnknownStatusProvider.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+
+package org.eclipse.hono.deviceconnection;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.eclipse.hono.util.AdapterInstanceStatus;
+
+import io.vertx.core.Future;
+
+
+/**
+ * Status provider that always returns the {@link AdapterInstanceStatus#UNKNOWN} status.
+ *
+ */
+final class UnknownStatusProvider implements AdapterInstanceStatusProvider {
+
+    @Override
+    public AdapterInstanceStatus getStatus(final String adapterInstanceId) {
+        return AdapterInstanceStatus.UNKNOWN;
+    }
+
+    @Override
+    public Future<Set<String>> getDeadAdapterInstances(
+            final Collection<String> adapterInstanceIds) {
+        return Future.succeededFuture(Set.of());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
     <module>bom</module>
     <module>core</module>
     <module>cli</module>
-    <module>client-device-connection-infinispan</module>
+    <!--<module>client-device-connection-infinispan</module>-->
     <module>clients</module>
     <module>demo-certs</module>
     <module>examples</module>
@@ -235,6 +235,8 @@
     <module>site</module>
     <module>test-utils</module>
     <module>tests</module>
+    <module>client-device-connection</module>
+    <module>caches</module>
   </modules>
 
   <pluginRepositories>

--- a/services/command-router/pom.xml
+++ b/services/command-router/pom.xml
@@ -24,10 +24,25 @@
   <description>A Quarkus based implementation of Hono's Command Router API that is using Infinispan for storing data.</description>
 
   <dependencies>
+    <!--
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>client-device-connection-infinispan</artifactId>
     </dependency>
+    -->
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-client-device-connection</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-cache-infinispan</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
+      <artifactId>hono-cache-redis</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-command-amqp</artifactId>

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/AdapterInstanceStatusService.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/AdapterInstanceStatusService.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.hono.commandrouter;
 
-import org.eclipse.hono.deviceconnection.infinispan.client.AdapterInstanceStatusProvider;
+import org.eclipse.hono.deviceconnection.AdapterInstanceStatusProvider;
 import org.eclipse.hono.util.Lifecycle;
 
 /**

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandTargetMapper.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/CommandTargetMapper.java
@@ -15,7 +15,7 @@ package org.eclipse.hono.commandrouter;
 
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.commandrouter.impl.CommandTargetMapperImpl;
-import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.DeviceConnectionInfo;
 
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/Application.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/Application.java
@@ -64,7 +64,7 @@ import org.eclipse.hono.commandrouter.impl.kafka.KafkaBasedCommandConsumerFactor
 import org.eclipse.hono.commandrouter.impl.pubsub.PubSubBasedCommandConsumerFactoryImpl;
 import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.config.ServiceOptions;
-import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.DeviceConnectionInfo;
 import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.service.NotificationSupportingServiceApplication;
 import org.eclipse.hono.service.amqp.AmqpEndpoint;

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/DeviceConnectionInfoProducer.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/DeviceConnectionInfoProducer.java
@@ -23,20 +23,18 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
+import org.eclipse.hono.cache.Cache;
+import org.eclipse.hono.cache.CommonCacheConfig;
+import org.eclipse.hono.cache.CommonCacheOptions;
 import org.eclipse.hono.commandrouter.AdapterInstanceStatusService;
 import org.eclipse.hono.commandrouter.CommandRouterServiceOptions;
 import org.eclipse.hono.commandrouter.impl.KubernetesBasedAdapterInstanceStatusService;
 import org.eclipse.hono.commandrouter.impl.UnknownStatusProvidingService;
-import org.eclipse.hono.deviceconnection.infinispan.client.BasicCache;
-import org.eclipse.hono.deviceconnection.infinispan.client.CacheBasedDeviceConnectionInfo;
-import org.eclipse.hono.deviceconnection.infinispan.client.CommonCacheConfig;
-import org.eclipse.hono.deviceconnection.infinispan.client.CommonCacheOptions;
-import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
-import org.eclipse.hono.deviceconnection.infinispan.client.EmbeddedCache;
-import org.eclipse.hono.deviceconnection.infinispan.client.HotrodCache;
-import org.eclipse.hono.deviceconnection.infinispan.client.InfinispanRemoteConfigurationOptions;
-import org.eclipse.hono.deviceconnection.infinispan.client.InfinispanRemoteConfigurationProperties;
-import org.eclipse.hono.util.Strings;
+import org.eclipse.hono.deviceconnection.CacheBasedDeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.DeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.infinispan.InfinispanRemoteConfigurationOptions;
+import org.eclipse.hono.deviceconnection.infinispan.InfinispanRemoteConfigurationProperties;
+import org.eclipse.hono.deviceconnection.redis.RedisCache;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
@@ -65,14 +63,14 @@ public class DeviceConnectionInfoProducer {
 
     @Produces
     DeviceConnectionInfo deviceConnectionInfo(
-            final BasicCache<String, String> cache,
+            final Cache<String, String> cache,
             final Tracer tracer,
             final AdapterInstanceStatusService adapterInstanceStatusService) {
         return new CacheBasedDeviceConnectionInfo(cache, tracer, adapterInstanceStatusService);
     }
 
     @Produces
-    BasicCache<String, String> cache(
+    Cache<String, String> cache(
             final Vertx vertx,
             @ConfigMapping(prefix = "hono.commandRouter.cache.common")
             final CommonCacheOptions commonCacheOptions,
@@ -81,6 +79,7 @@ public class DeviceConnectionInfoProducer {
 
         final var commonCacheConfig = new CommonCacheConfig(commonCacheOptions);
         final var infinispanCacheConfig = new InfinispanRemoteConfigurationProperties(remoteCacheConfigurationOptions);
+        /*
         if (Strings.isNullOrEmpty(infinispanCacheConfig.getServerList())) {
             LOG.info("configuring embedded cache");
             return new EmbeddedCache<>(
@@ -94,6 +93,9 @@ public class DeviceConnectionInfoProducer {
                     infinispanCacheConfig,
                     commonCacheConfig);
         }
+         */
+        LOG.info("Creating a new REDIS cache.");
+        return new RedisCache<String, String>();
     }
 
     private EmbeddedCacheManager embeddedCacheManager(final CommonCacheConfig cacheConfig) {

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImpl.java
@@ -38,7 +38,7 @@ import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.commandrouter.CommandRouterResult;
 import org.eclipse.hono.commandrouter.CommandRouterService;
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.DeviceConnectionInfo;
 import org.eclipse.hono.service.HealthCheckProvider;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.CommandConstants;

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandTargetMapperImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/CommandTargetMapperImpl.java
@@ -23,7 +23,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.client.registry.DeviceDisabledOrNotRegisteredException;
 import org.eclipse.hono.client.registry.DeviceRegistrationClient;
 import org.eclipse.hono.commandrouter.CommandTargetMapper;
-import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.DeviceConnectionInfo;
 import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.DeviceConnectionConstants;
 import org.eclipse.hono.util.MessageHelper;

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/CommandRouterServiceImplTest.java
@@ -41,7 +41,7 @@ import org.eclipse.hono.client.telemetry.EventSender;
 import org.eclipse.hono.client.util.MessagingClientProvider;
 import org.eclipse.hono.commandrouter.CommandConsumerFactory;
 import org.eclipse.hono.config.ServiceConfigProperties;
-import org.eclipse.hono.deviceconnection.infinispan.client.DeviceConnectionInfo;
+import org.eclipse.hono.deviceconnection.DeviceConnectionInfo;
 import org.eclipse.hono.test.VertxMockSupport;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.EventConstants;


### PR DESCRIPTION
This PR is very much WIP still.

So far I have refactored the `client-device-connection-infinispan` module into 3 cache modules (common, infinispan and redis) and a `client-device-connection` module.

The idea is that the `client-device-connection` can be backed by different types of caches, one being the Infinispan data grid that has been used in Hono so far but another possibly being Redis.

Currently I've only refactored the module structure and copied the existing code to new places. I've added an extremely crude proof of concept implementation for a Redis cache and hard coded that to be the type of cache that is created (it works, but as I said, it's not configurable in any way and the implementation is absolute garbage).