### PR TITLE
Improve tests for Registry Management's search entities API

### DIFF
--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/utils/MongoDbDocumentBuilder.java
@@ -288,8 +288,14 @@ public final class MongoDbDocumentBuilder {
     }
 
     private void applySortingOptions(final List<Sort> sortOptions, final Function<JsonPointer, String> fieldMapper) {
-        sortOptions.forEach(sortOption -> document.put(fieldMapper.apply(sortOption.getField()),
-                mapSortingDirection(sortOption.getDirection())));
+        if (sortOptions.isEmpty()) {
+            // if no fields to sort by have been specified, sort by "/id"
+            document.put(fieldMapper.apply(FIELD_ID), mapSortingDirection(Sort.Direction.ASC));
+        } else {
+            sortOptions.forEach(sortOption -> document.put(
+                    fieldMapper.apply(sortOption.getField()),
+                    mapSortingDirection(sortOption.getDirection())));
+        }
     }
 
     private MongoDbDocumentBuilder withCredentialsPredicate(final String field, final String value) {


### PR DESCRIPTION
Extended the unit and integration tests for the search API to use a larger set of entities so that paging functionality can be tested more meaningfully.