### PR TITLE
Add image-only Hono logo in SVG format

### DIFF
--- a/site/homepage/static/img/hono-logo_image.svg
+++ b/site/homepage/static/img/hono-logo_image.svg
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" baseProfile="tiny" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 135 125" xml:space="preserve">
+<metadata><?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c111 79.158366, 2015/09/25-01:12:00        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stRef="http://ns.adobe.com/xap/1.0/sType/ResourceRef#"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/"
+            xmlns:ExtensisFontSense="http://www.extensis.com/meta/FontSense/">
+         <xmp:CreatorTool>Adobe Illustrator CC 2015 (Windows)</xmp:CreatorTool>
+         <xmp:CreateDate>2016-05-24T17:43:05+02:00</xmp:CreateDate>
+         <xmp:ModifyDate>2016-05-24T17:43:05+02:00</xmp:ModifyDate>
+         <xmp:MetadataDate>2016-05-24T17:43:05+02:00</xmp:MetadataDate>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>256</xmpGImg:width>
+                  <xmpGImg:height>132</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgAhAEAAwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8A9U4q0zKqlmNFAqSegAwE&#xA;0oFvHtY8w6/ql/cataSyxWVo4EPB+IRa0U8ajkT1bb8M4HVa7PmnLLAkQidt+X46vZ6fSYcUBjkA&#xA;ZS5/j7nqHlzVv0totrfGgklSkoHQOp4t+Izs9BqfHwxn1PP39XldZg8LLKHd9yZZmOM7FXYqwn8y&#xA;dZuY0tdFs2Kz3xrKQeJ4E8VWvYM3X5Zznb+rkBHDD6p8/dyr4u97G00STllyj+PsSz8u9QvNP1uf&#xA;QbpvgkDNHHWoWRRyPH/WSpOYfYWeeLMcEuR+/wDscntjDHJiGaPT7v7WXSXV7DrN4kKSXCekren6&#xA;gAQ+IDkD7s30sk45pAAyFd/L5unEIyxRJob93NRW4n/RGmq9xJGt09J7kseYBqaBj0rlYnLwoAyI&#xA;4juf2szAeJOgDwjYIqxJt9WazhuHuLcw+o6u3MxsGAHxe4PTLsPpy8AJlHhvfemrL6sfERRv5pR+&#xA;ktQW1eKWWThcT8bedWPJSsgDJy6j4dxmB+YyCJBJqUtj8dw5ngw4gQBtHcfDmnF9WbVYrKW4eC3E&#xA;PqAI3AyPypQt7DemZ+b1ZRAkiPDfdZcPF6cZkBZv5L9FlkJu4DK1xDBLwhnY8iQQCVLd+JyekkfV&#xA;G+IROxY6mI9JqiRuEzzMcV2KsZ8/eYJdI0cLbNwvLtjHE46qoFXYe4qAPnmm7b1xwYqj9cth+ku0&#xA;7J0gzZPV9MfwGLeS9X1jTPMMemam8npXopwlbnxcg8GBqepHE/j0zS9k6rNh1Ax5Can39/T9Tte0&#xA;tPiy4Tkx1ce78fF6fnZvLKdwivbyowqrIwI9iMhkFxI8mUDRBY3C15JYaSk0ai2aeMBw5Lts2xFB&#xA;+vNREzOPGCPTxDr73ZyEROZB9XCUTcLpsuqXa6q4URhPqquxReBWpKUIqa5dkGOWWXinlVXtt5NU&#xA;DMY4+H8VKZ5X8tIskjD1JlSCRzR2T1PhO/fjkJknTizzlt31ezOIAz7DkN/kraZJcya40d2D9Ytb&#xA;b02bsx57OP8AWVhk9PKRzVP6oxr7efyYZxEYrjylL9HJBkaa1lcT3cpXWFaSnxsJVcMeCotenTKP&#xA;3ZhKUz+936730pu9YkBEfu9vd52yW0MxtYTMKTFFMg/yqCv45uMV8IvnTrMlcRrlark2DC/POkPq&#xA;msaVESBbxK8lzUtunqRqVUKGYs1aAAZz3bGlObNjH8Isn3XHu6no7vsvUDFimepoD30fsQel6JJb&#xA;+cNO1GCEQ2koaOVACnGU28h2H2SrcagqSPGhzH02jMNXDJEVE7Hpvwn7Nun3t+fVCWmnAm5D7uIf&#xA;jdnN/fW9jZy3dwSIohVqCpJJoAAOpJNBnSZs0ccDOXIOhxYpZJCMeZYZpXmQw67Pd307i0uhIHiJ&#xA;5GCktITLGCTEBHUE06/azn9Nr+HOZzJ4ZXt/N39Nj+Hb9rus+j4sQjAeqNfHb1Ueu/7GdZ0roUk8&#xA;w+YdDtIptOu71be5uImRRxd+PNSoLcA3Hr3zW67XYIA45y4ZSHn19znaPSZZkTjG4g/d73mCabeQ&#xA;eWr2T4WjmnhKsjBg0UXqq8gA/Z9QqM40aecdNI9DKPyHFZ9109Sc0ZZ4jqIn5mqHytm/5f63oEem&#xA;w6TFdH65VmZZV4c3Y1ITqDTp1r7Z0fYmrwDGMQl6/Pa/c6PtbTZjM5CPT5fpZnnQukdiqG1LU7LT&#xA;bN7u8kEUCdSdySegUdycp1GohhgZzNANuHDLLLhiLLzTXrnTvM/mCzudOnKkIFnimVlKpEWkLggM&#xA;CKdutc4/W5MeszxljPTcHuFm3p9LCelwyjMe6vPakNp+oWWiecLi+1OOUuskjwrEFIpOCQ5qVqOD&#xA;9MpwZ4afVynkB5kiv6XX5FszYZ59MIYyOQu/Lp8w9P0270rUojqFi6TLMODyL12/ZYHcEeBzs9Pk&#xA;xZR4kDdvLZseTGeCe1Ij6na/VhbGJTbgUEZFVp9OW+FHh4a9LX4kuLivdq2sbO2RkghWNW+0FFK/&#xA;PHHhhAVEUmeWUjZNtDTrEQLbiFRCrc1SmwYGtcAwQ4eGtl8ad3e665s7W6QJcRLKo3XkK0+WHJij&#xA;MVIWiGSUPpNL4YIYIxFCgjjXoqigyUICIoCgiUjI2ea/JMVk88NvC887rHDGCzyMaAAdycjOYiDK&#xA;RoBlCBkaG5LzXzrf6d5lmsV0i5Wa4idojAwaMn1CtHUuAtBTffOP7XzY9WYDFK5A1W451vu9N2Zi&#xA;nphLxBQO98+SXSyWun+cYrvUndbeD0ZIWiHPmI0CqQSR8PJKHvmLKUcWrE8hPCKIre6G3w2cmIlk&#xA;0xjDmbG/Sy9U03VLDUrYXNjMs8J2qvUHwYHcH552un1OPNHigbDyebBPFLhmKKKIrsemXtSz0YeK&#xA;L6a8YzVFoKKR3HhkeAcq5MuI97pYIJaerGsnH7PIA0+VcZQjLmLWMiORbeKJwA6KwU1UMAaEdxXC&#xA;Yg8wgSI5N+mnP1OI50486b060rjQu+q2apaYIGkEpjUyDo5Uch9OAwjd1ukTNVey/JMXYqx3zRJo&#xA;Zu7O3v47h7mdZVh+rO0fwChkDkPGOO1d/DNT2jLDxxjMSMjdcJrbre42dloRl4ZSgY8Iq7391bFR&#xA;8qaT5XmVNT0uCZGt3kiRZnf4GIo/wFmHRsr7M02mlWTEJDhJG5O3ftbPX6jUC8eQjejtW7Iryztr&#xA;y3e2uUEkL05ISR9khhuKHYiubbLijkjwyFgutx5JQlxRNFLLLTfK+o2kbW9nBLBAxEfKICh61+IV&#xA;PKobfr1zDw6fTZYAxjExHl+OfPz5uVlzZ8cjciCfP8e5Mr+6FpY3F0V5C3ieUqOp4KWp+GZebJwQ&#xA;lL+aCfk42KHHMR7zTxSF7C6Nzqmq3Dy3Bk5fVE+FpWbf7ZrxX5A9O22edxMJ8WXLK5X9Pf8AHoPx&#xA;3PcSE4VjxihXPu+HU/jvTe3n8zTaJdanbKLXTrUqIrdIk9NoySHUBgzOorVuRNe+Z0J6mWGWSPpx&#xA;x5ChVdfeO+/i4c44I5Y45eqcut73093kkt1eaTPaGRLU2upcwf3JIhI7sFYkqfYe1KdM1+TLilGx&#xA;HhyeXL9n4pzYY8kZUTxQ8+b1jyTf3995dtp70N6w5IJG6yIpor79fnncdkZ55NPGU+f3+byPaeKG&#xA;PMRDl9ye5s3Aea/mdemXWrHT53aKxRBK7AV3kYqWp34hf15x/tDlvNDHI1AC/m9P2JjrFKY3ldfJ&#xA;JbD67c3f6O8rwyRISBLe1PqsK/aeSi8E/wAkUr3qc1+DjnLw9MCO+XX4noPL525uXhjHj1BB/o9P&#xA;gOp81+tS3+k6tLp+rRnUbFZCYTcglzGxqGjlBDDruA1K9clq5TwZTjyjxIXtxc68jz+2rRpowzYx&#xA;PGeCdb13+Y5fpRn5eS33+JnOnxOumS8/rCkkqqAEx1b+YNSnfL+wpT/M/uwfDN37unxaO14w8D1k&#xA;cY5fpeq527ybsVdirsVdirsVYH+ampSpb2WmqxSK4YyTvvQhCAo267mp+jOY9pNQRGOPkJbn4PQd&#xA;hYQTKfUcmJRywWV0troCte6g9At8VqwJ7QR7hfdzU+FM0UZRxy4cHryH+L/iR+n5U7cxM48Wb0w/&#xA;m/8AFH9H3orX5dU02+Sy1uNb+B443AkAUryUcxDInHjxeooNvEZfrZZcM+DMOMUOfu34SOW/w8mr&#xA;SRx5YcWI8Bs/ssHy+LXlS/e382wLoyymzuJFjlhfcmI0DswFfs7sPDB2bmMdUPBvgkaI8uvy5rr8&#xA;Qlpz4tcQF359PnyewZ3zxrsVdirsVdirsVdirsVSTzBo0t9cW80M8MMsaPGDMjMaPSvAq8ZHvmt1&#xA;2kOSQIMQRY3Hf3UQ52k1IxxIIJG3L+wovRNLfTraSN2RpJZTK/pKyICQF2DM7b8amp65fo9McUSD&#xA;Vk3ty+0lq1WcZJAi9hW/4CIv7eS4tJIY5jAXoDKK1C1BYbFSOS1FQdsuzQM4EA8LVimIyBItB6Po&#xA;n6MkkKXLSRSKo9IqqKCoAqAgVegpsB71zH0uj8EmpWD02/R+O+27UarxQLFEfjquOsW76Y920LtH&#xA;z9FoSFJJLcadad8J1UTjMq25V9i/l5CfDfnaVy6D5Xs7xUt9HW4uyvqGMDkqqT1IclRv02zClotN&#xA;jnUcXFLn+L2cqOqzzjvkqPL8VunEWqWzafLcrGyrbhllgIAZSg3WnTNhHUROMyr6eYcOWCXGI3z6&#xA;oCJPLks9o8OmwPLeBmWQQxVXhSvI0rtmLEacyiRCNz/ohvkc4EgZmo+ZRk2sBJZY4LWW4W3PGZ4w&#xA;OKmm4FSKkZkS1VEiMTLh500x09gEyAvkjbe4iuIEniPKOQclOZGOYnESHItE4GJo8wpXul6bfcPr&#xA;lrFc8PseqivT5VGQy6fHk+uIlXeGePPPH9MiPcq29tb20Yit4khiHRI1CqPoFBk4Y4wFRAA8mE5y&#xA;kbkbK90RxR1DDwIrkiAeaASG1VVACgADoB0xApBLsKuxV2KuxV2KuxVB6lo+manGsd/bpcKhJTlW&#xA;qk9aEUIrmPqNLjzCpxEqbsOoyYjcDTen6RpmnqVsrWO35faKKAT826nDg0uPF9ERFcuoyZPrJKtc&#xA;WtrcqEuIUmQbhZFDCvyIOWTxxmKkAfewhklHeJIdb2dpbAi3gjhB6iNVSv3AYIYoQ+kAe5Z5JS+o&#xA;kquWMHYq7FXYq7FXYq7FXYql+o6LbX1zBcSkh4Ps0puOQb9ag5i59JHJISP8Lk4dTLHEgdUwzKcZ&#xA;Surdbm3eBmZFkFGZKVpXcbgjfochkx8cTHvZ458Mrbt4RBBHCGZxGoUM9CxA2FSAMYQ4YgdyJy4i&#xA;T3pIPLjfVWqq/WzP6gfk1OHMN8untmuGg9P9Liv7XO/Oer+jX6EddWl9HfG8svTYyII5opSQDxOz&#xA;AiuZOTFMT44VuKILRDJAw4Z3typSOmXg0y8jLI95eEs9KqgLUWg2rsuQ/Lz8OQ2M5/Jn48fEif4Y&#xA;/NZb6G9vqsF1Ew9BUb1Y6naRl4kqP8rIw0ZhlEhy6++kz1QljMTz/QqfU9WtZrgWRhaG5dpQZSwZ&#xA;Hf7XQGoyXhZYGXBVSN79Cx8THIDjuwK26o3T7QWdlFbBuXprQt4nqfxzJwYvDgI9zRmyccjLvRGW&#xA;tbsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdi&#xA;rsVdirsVdirQkQsVDAsv2h3GDiCaLQliKc+Q4fzV2wcQq14TdOSSOQVRgwHWhrhEgeSmJHN3rRcC&#xA;/McQaE12rg4hVrwnk55Y0ALsFB6EmmEyA5qIk8m1ZWXkpDA9CN8QQeSkU3hQ7FXYq7FXYq0zBVLH&#xA;oBU/RgJpQFhuIgivy+FyApodycjxirZcBumpbmCJuLtRutKE/qxlkiOaYwJ5LmniWP1S37s/tdev&#xA;ywmYAvogRN036sfqCOvxkcgPbHiF0jhNWpteWyuUL7g0OxpX59MicsQatkMclbLGDsVdirsVdirs&#xA;VdirsVQdxfvFqVrZiEuLlZGMtQAojA7f7IZjzzGOSMK+q9/c3QxAwlK/pr7UZmQ0uxV2KuxVZcSP&#xA;HbyyIvN0RmVCaVIFQK70yM5ERJDKABIBUNLuprvTre5mQRvMgcqDUUbcH6RvTtlemyGeOMiKJDPP&#xA;AQmYjoWnjlN3KUYoOA3pWuAxPEa7kgjhFrfTYWtuShZUNXSm/wB2R4Twjbkm/UV8NHuTLGhSMJQk&#xA;inI18MlDeVgbMZbRo80KIphFyUEpI/xKQaijVBynhNe8tvEL9wRU9EuVkdC8fDiCBWhr4ZfPaVkb&#xA;NUd40Oa60Uj1GClEdqoh27dae+HEOZ5BGQ8kRlrW7FXYqg9I1CS/shcPCYCWdeBPL7DFTvt3FMx9&#xA;LnOWHERXP7G/UYhjlwg2jMyGhpvsn5YCoQSW0qx25JYlXBZDSgG+Y4xmg3mYsqp9SGeRvTMiyUIK&#xA;0rsKUOT3jImrtjsQN+SxoJBZiMrVmcEqOgBNciYHgrzZCQ4rXW8Esdy1d4wnGNvataYYQIl5Uicg&#xA;Y+awLMkL2/oli3IB9uJr3OCiAY0mwTxWi41KRqpNSoAr8hl8RQppJsrsKHYq7FXYq7FXYq7FWK3H&#xA;mKD/ABKkhXnZWiSW5uEDOAZfTZ5CwBUKjR8D4b/LNJPXR/Mg/wAEQRfPnRJ9wqnbQ0Z8Cv4pEGvd&#xA;dD3m7ZRFNFNGssLrJG4qjoQykeIIzcxkJCwbDqpRINHYrskh2KuxVJ/MmqNa2TW9r+8v5xxjhVWk&#xA;cITR5OCfFRVr9OYHaGoMIcMd5y6czXU0O5zNFg4pcUtoDry9wstaDq0DWltY3Km0vo4wgt5VaMsq&#xA;CgZA9KgqK0FadDg0WpjwRhL0zA5Hbl1F/gdU6vAeIzj6ok8xvz7/AMbpzmwcJ2KuxV2KuxV2KuxV&#xA;2KoLWdTTTbCS5NGlApBETQu56KKVJ+gVzG1eoGLGZdeg7y36bAckxHp18kt8q6rbvZR2UrCK7Qtw&#xA;RgU9VSS3OLlTku9DStDmJ2bqYmAgdpfK/Md7k67BISMxvH7vIp/m0de7FXYq7FXYq7FXYq7FXYq7&#xA;FXYq7FXYq7FUu1DS5765jElyy6dxIntUqpkO+zOKNxNdx7e+YmfTyySFy/d9Y9/x7vx1cnDnEImh&#xA;6+h7vgj4oooY1iiRY40HFEUAKAOwAzJjERFAUHHlIk2eaDh0Wxgvze26mF2BDxx/DGxP7TKO+UQ0&#xA;kIz447Hy5N0tTOUOE7/ejsyWh2KqV1C81tLFHK0LupVZV6qSOoyGSJlEgGierOEhGQJFqGmaXb2E&#xA;RCkyXElDcXLktJI3izMSaDsK7ZVp9NHENt5HmepbM+c5D3DoOgVL+wtL+2a2uoxJE3YitD2I8CMn&#xA;mwwyx4ZCwwxZZY5cUTRVLeCK3gjgiFI4lCICa0AFB1yUICMREcgxnMyJJ5lUybF2KuxV2KuxV2Ku&#xA;YEqQDQkbHwwFQl2m6P8AV3+s3cpvL81X6w/7KE/ZjXoo8adcxdPpeE8UzxT7/wBXd+lyc2o4hwxH&#xA;DDu/X3oq8sbS9hMN1EssZ3AYVoexU9QR4jLsuGGQVIWGrHllA3E0XWFmlnaR2yO7rGCA0hq25r2p&#xA;jhxDHERBJrvXLkM5GR6q+WtbsVdirsVdirsVdirsVdirsVdirsVQIvX9Aiv77lxrxNKVp8sxvGPD&#xA;5t/hC/JWd52mMUbBeKgs5FevgMsJJNBgAALLQuJfQmLU9SKoqOhoK1wcZ4T3hPALHcVkV3JJLEmy&#xA;sa+qKdwK/jkY5SSB80yxgAlfzuZWkMbKixsVAIrUjrXJXKRNdEVEVarby+rCklKFhuMshLiFsJxo&#xA;0qZJi7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FVH6rH6Rjq&#xA;eJblXata18Mr8MVTPjN23LbrI4fkyOBTkpoaeGGUATaxnWzvqsfotECQG+01fiPjucHhiqXjN276&#xA;tF6qyiodRx+Y6b4fDF2vGapp7RGZmDOnP7YU0BwHECVGQhVRFRQqiijYDJgUKYk23hQ7FXYq7FXY&#xA;q7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FWI61+Y+nabqxsFt2uU&#xA;ibjczqwHA9wq0PIr33GaHV9vY8OXgA4q5nu/X9juNN2NPLj474b5D8cmV288NxBHPCweKVQ8bjoV&#xA;YVBzeQmJREhuC6mcDEkHmF+SYuxV2KpR5o8x2+g6d9ZkX1ZpG4QQ1pybruewHfMDtHXx02PiO5PI&#xA;OZodHLUT4RsOpQPk/wA5R6/60MsQgvIRz4KaqyE05Cu+x2OY3ZXao1VgjhmPucjtHs46eiDcT96c&#xA;R6mrX9zZtEytboJOdQQyt4ZsI6i5yhX0i3COCoCV81Aa9H+joLz0HL3TcLe3UguxNae3auVfnR4Y&#xA;nR9XINn5U8ZjY9PMqtjqrT3L2lxbPaXSr6gjchgyVpVWXY75PDqeKXBKJjLmwy4OGPFE8UUKvme1&#xA;e0uJkjZpLeURNBUBiWbipB6UOUjtGJiSBvE1TadDISAJ2Iu0Ve6q0E8drBbvc3kiep6KlVCpWlWZ&#xA;thvtl2bU8MhGMTKZF1+1qxYOIGRPDHvVNO1GO9jchGhlhbhNC/2lbr2yeDOMgO1EcwxzYTAjeweR&#xA;ReXtLsVQer6raaVp8t9dEiKIdB9pmOwVfc5j6rUwwYzOXIN2nwSyzEI8ykvlbz1aa7cyWrQG0uVH&#xA;ONC/MOo60NF3Hhmu7N7ZhqZGNcMvfdudruy5YIiV8UWTZuXVrJ3dIZHQBnVSVUmgJA2BO+RmSASO&#xA;bKIBIBShfMaSWljJCsb3F3IkbQeoKpyruaCu1PDMAa8GECK4pECr5OYdHUpA3URd0rT6nqD3k1tp&#xA;9sk31anrSSPwBZhyCrse3fLJ6jIZmOON8POzXwYQwQERKZri5Usm1/jo36RjgJkDiN7cncPz4Fag&#xA;ZGetrD4gG91XndJjpLy8BPxVbTWlvL6KG3UNBJbi4MpNGFWKceNOoI33yeLVjJMCP0mPFfxpjk03&#xA;BAmXPipDHXNReGW9t7JZNPiLfEXpI6oSGZVpTahyk6zIQZxjeMee5rq2flYAiEpVM+WycQTJPDHN&#xA;GaxyqHQ+zCozYQmJAEci4comJIPRfkmLsVdirsVdirsVUNQne3sLm4QVeGJ5FHiVUkZVnmYQlIdA&#xA;S2YoCUwD1IeHwiGTSb65mT1LgSxKkxY1DSc2Pz2jOecRAOKciLlY399/qe6kSMkYg7UdvdX63qn5&#xA;etcHypaesCKFxET1KczT+zO17DMvyseLzr3W8n2uI/mJV5fcyPNu612KuxV5n+Zc0zeZdPhdOcCR&#xA;oyRturF5CG6ePEDOO9oJk6iESLiAPtO71HYsQMEiOd/oUPJsMx89ytaRcLSFpkmKD4AgVlWtNvic&#xA;A0H0ZX2VA/niYD0jiv3f2s+0ZD8oOI+o1X49zO7jQIrrVLi6uUjlieJUiVq8lcdSds6bJohPKZSA&#xA;II2dDDVmGMRiSDbQ0W7XTLGKOVEvrEho3NWjJoQVPQ0IOAaSYxwAI44fJfzMTkkSPTP5q1nY6ib5&#xA;r+/eIzLGYoYoeXBQTUkltyTlmLDk4+OZF1QA5MMmWHBwQurs2lh8qXBtoj6kaXizF5Spbg0ZfnxJ&#xA;pU0IqNswv5NlwjccfFv3Vd05X5+PEdjw19tUml9Y3/15L+weMTen6Mkc3LgycuQNV3BBOZubDPjE&#xA;8ZF1W/JxcWWHBwTurvZU0uwnt/XnuXWS7unDzFAQg4jiqrXegHjk9NhlC5SNykd2OfKJUIiox5I7&#xA;Mlx3Yq8+/Nq5mEenWo2hcySN7svFR9wY/fnK+02Q1CPTc/c9F2BAXOXXYJFpKel54sI7CH0wjxh0&#xA;Uk/CyVk3PgrEe+azTCtbAYxVEfdv9jn6g3pJGZvn9+z17O9eOadeSMvTkCK/PARYSDRSiLy7FHbW&#xA;EalBNZypJJMEAZwtdq9d65gR0AEYAVcSDdc3MlrCZSO9SFVfJUuNKvRdzXNhd/VjcAeujIJAWUUD&#xA;LUihpk56afGZY5cPFz2v4sYZ48IjOPFXLelsuhf7jIrGGbiFlWWaVxyZyG5t3G5bBLRfuxAHrZPf&#xA;1THVfvDMjpQ8lS00SK11a4vomok6cTDToxbkSD4HwyWLSCGUzHKQ5McmpM8YgenVDtoN6sclpBfG&#xA;LTpSxMPAF1VzVlV69DXwyo6KYBhGdYz0rffmLbBq42JGNzHW/wBCcQxRwxJFGKRxqEQeAUUGZ8Yi&#xA;IAHIOFKRJJPVdkkOxV2KuxV2KuZlVSzEBQKknYADATSgPKtT85+ZdV1WQaO7xWcZKxKoWnEV+OVm&#xA;FBUCu+wzitR2tqM+U+CSIDl+s/inrMPZuDFjHi7yP4oIOS40T9GyWU0nKVnD3N1bQj0xOSxRgQU+&#xA;FVJWgFOtBmPKeHwzAne9zGO3FvXdsOXL3Nwhl4xIDboCd669+55/eq6dr3mbQuN0lyNR0yoUj1PU&#xA;QjwAb95GfmB2qMng1up03qEvEx++x+uPyY5tLgz+kjgn7q/YXqGj6ra6rp0N9bE+nKN1PVWGzKfc&#xA;HOz0upjnxiceReW1GCWKZhLmEZmQ0MP/ADB8y3enRQabpzFb683Lp9tY68Rxp+0x2B9s0HbnaE8Q&#xA;GPH9cvnXl73c9kaKOQmc/oj9/wCxhsF7dWLRS65dSzyJVrayc+tKjMCPUbmaR0rUDqT9+c/DNLHR&#xA;zyJI5R5kee/L3f2u6lijksYgAOsuQPltz/HuUZ44LvUZGsZ30/UeZD20p4VkGzFJE6MWFeJA36E5&#xA;XOMZ5DwEwyXyO2/kR18vk2QJhAcY44VzHd5g/f8ANmHknzheXF6dE1Y87xOSwz7EsUHxI9OpoOub&#xA;/sjtWcp+Dl+vofd0Lpe0+zoxj4uP6eoZxnSOidirsVdirsVdirH/ADr5kbQ9LDwUN7cEpbg7gU3Z&#xA;yO/H9eartftD8tiuP1y2H63Y9m6Lx8lH6Rz/AFPPk1DVpVjn8xXDPp6uJUt7hA8krLvSJCAwXxNQ&#xA;vb2zlo58sgJag/u7uiNz7h/YHoThxixgHrqrHIe/8EtXcyXd+Z9LvJLG/kVOUcn+jeqSAVZGRuIq&#xA;pFAxHj3wZZic+LFIwma5+m+6iNvgaTjiYQrJESgP86veybyl5z1BdQTRNc3uGosFzUEliKqrldjy&#xA;7EZuezO1sgyDDn+rof0H9bq9f2bDg8XFy6hnmdM6B2KuxV2KuxV2KuxV2KuxV2KuxV2KqF/bG6sb&#xA;m1DcDPE8QcdV5qVr9Fcqz4+OEo8uIEfNsxT4JiXcQXnNt+XPmhYnsmu7eKykblIQWYmlOg4g70G1&#xA;R0zksfYOpAMOKIgfx3PST7Y09iXDIyH472SWv5e6RBotxp3NnlugpluyByDIarxXoAD2/HNxj7Dx&#xA;Rwyx3vLnL3Osn2vkllE+keiQj8qb6pi/Sii3LAmkbbkbAlOVK7+OasezU+Xien3fot2H8vQ58G/v&#xA;ZtoGiW2i6aljAzOqks8jdWZupoOmdHotHHT4xCO7o9XqZZ5mZTHMtxmI+bfJN3rGpw6jZ3awTRoq&#xA;FXB24sSGVl/1s0PafZE8+QZIS4SBTuOz+044cZhKNgrdH/LiytroXup3DX9yG58SOMfLrUipLfq9&#xA;sGl7BhCXHkPHL7P2p1HbM5R4cY4I/av178utO1S/kvo7h7WWY8pVCh1LeIFVIJ775LW9g480zMSM&#xA;SeaNL2xPFAQIEgFXy75A03R7xb0zPdXSAiNmAVV5ChIUV3oe5yeh7Ex6efHZlIMNZ2tPNHhoRiyj&#xA;N06p2KuxV2KuxV2KsU88+U9Q1trSexmRJbbkCkhKghiDVSAdxTNH2x2Zk1PDKBFx73b9l6+GDiEx&#xA;tJLbH8tbm4uxd69eLMdqwwAgEDsWotB7BcxMPYEpz488r8h+B9gcnL21GMeHDGvMo7zJ+Xdpqtyt&#xA;1az/AFOQIsbR8OSFUHFaAFaUUAZk6/sKOeXFE8BquW2zRou2JYo8MhxD396jov5ax2epRahe3zXU&#xA;kLiVEVeNXU1BZizE75XpOwBjyDJOfEQb+LPU9tGcDCMeEEUzXOidG7FXYq7FXYq7FXYq7FXYq7FX&#xA;Yq7FWFq17+g3h4L9S+tcDJ6jc6eqPh406fTnOgz8AivRx9+/1fjq7siHig36uHu8k01JbCTWvq+q&#xA;ycLNYFNqjuUjZqnkSaj4ht3zN1Agc3DlNQ4dt6Hn8XFwmYxcWMeq9+9Rimp5d1XhIzWaNIlnI5O6&#xA;UAAVjuRy2GVxl/g+Sj6BfD7v7Wco/voWPVtahYPeHWdMs7yrm3jd4pamjoyAofmKUOV4TPxscJ/w&#xA;g0e8Vs2ZRHwpyj1I+HequukTXeotrExS6ilYQK0jIUhAqhiAIqT12yZGKU5nMakDtvVDpTAHJGMP&#xA;CHpI3269bTrQ5LmTSLV7qpnZByLdSOxP0ZsdHKRxRMudOFqhEZJCPK0dmS47sVdirsVdirsVdirs&#xA;VdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVdirsVQ4/R/oGno+hz3+zw51+6tcq/d8PThv&#xA;7Wz131tu7+o+mPrnpenXb1uNK/7LDl4K9dV5rj479N/BuT6l9V/een9UoPtcfTpUU6/D8sZcHDvX&#xA;D9iji4tr4vtbb6r6sfLh61D6NacqU349/uwnhscr6IHFR511U7n9G+qn1r0fV/3X6vHl1/Z5b9ch&#xA;k8OxxcN+dMocdem68kTlzU7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXY&#xA;q7FXYq7FXYq//9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:HasVisibleTransparency>False</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:HasVisibleOverprint>False</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>135.000000</stDim:w>
+            <stDim:h>125.000000</stDim:h>
+            <stDim:unit>Pixels</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Magenta</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Standard-Farbfeldgruppe</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+                  <xmpG:Colorants>
+                     <rdf:Seq>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=0 G=0 B=0</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>0</xmpG:red>
+                           <xmpG:green>0</xmpG:green>
+                           <xmpG:blue>0</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=255 G=255 B=255</xmpG:swatchName>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:red>255</xmpG:red>
+                           <xmpG:green>255</xmpG:green>
+                           <xmpG:blue>255</xmpG:blue>
+                        </rdf:li>
+                        <rdf:li rdf:parseType="Resource">
+                           <xmpG:swatchName>R=240 G=135 B=18</xmpG:swatchName>
+                           <xmpG:type>PROCESS</xmpG:type>
+                           <xmpG:tint>100.000000</xmpG:tint>
+                           <xmpG:mode>RGB</xmpG:mode>
+                           <xmpG:red>240</xmpG:red>
+                           <xmpG:green>135</xmpG:green>
+                           <xmpG:blue>18</xmpG:blue>
+                        </rdf:li>
+                     </rdf:Seq>
+                  </xmpG:Colorants>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+         <dc:format>image/svg+xml</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">0105_HONO_Logodesign_hik</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DocumentID>xmp.did:a2cbe778-795d-0b4c-97a5-97b47e7ee0f2</xmpMM:DocumentID>
+         <xmpMM:InstanceID>xmp.iid:a2cbe778-795d-0b4c-97a5-97b47e7ee0f2</xmpMM:InstanceID>
+         <xmpMM:OriginalDocumentID>uuid:7a9caafe-ac90-492c-880e-646dcc37f095</xmpMM:OriginalDocumentID>
+         <xmpMM:DerivedFrom rdf:parseType="Resource">
+            <stRef:instanceID>xmp.iid:7505e3e6-fd92-9d42-9e16-faa9741f0284</stRef:instanceID>
+            <stRef:documentID>xmp.did:7505e3e6-fd92-9d42-9e16-faa9741f0284</stRef:documentID>
+            <stRef:originalDocumentID>uuid:7a9caafe-ac90-492c-880e-646dcc37f095</stRef:originalDocumentID>
+            <stRef:renditionClass>proof:pdf</stRef:renditionClass>
+         </xmpMM:DerivedFrom>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:51e363a5-74d2-5b47-ae49-b54cfa274186</stEvt:instanceID>
+                  <stEvt:when>2016-03-29T16:46:47+02:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 2015 (Windows)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:a2cbe778-795d-0b4c-97a5-97b47e7ee0f2</stEvt:instanceID>
+                  <stEvt:when>2016-05-24T17:43:05+02:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 2015 (Windows)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <pdf:Producer>Adobe PDF library 15.00</pdf:Producer>
+         <ExtensisFontSense:slug>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <ExtensisFontSense:PostScriptName>MyriadPro-Regular</ExtensisFontSense:PostScriptName>
+               </rdf:li>
+            </rdf:Bag>
+         </ExtensisFontSense:slug>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>
+	</metadata>
+<g id="BG">
+</g>
+<g id="Logo">
+	<g>
+		<path fill="#F08712" d="M111.2,73c-5.3-3.7-12.9-8.6-20.5-9.3c-10.7-1-7.2,2.2-14.1,3.6c0,0-0.2-2,3.6-4.3
+			c4.9-2.9,10.3-6.2,12.3-12.3c2.3-6.9,0.4-15.2-1.6-21.5c-2.3-7.4-9.3-26.7-22-26.7S47.6,22.9,44.5,31.8c-2.1,6.2-4.5,14.9-3,22.3
+			c2.1,10.8,7.9,8.2,11.4,15.2c-6.3,1.8-13.1-1.5-18.6-2.3C21,64.9,8.7,82.3,3.2,101.6c-1.5,5.2-1.4,13,3.9,17.5
+			c5.6,4.8,18.7,5.3,36.9-2.7c6-2.6,14-6.7,18.6-12.7c5.4-7.3,2.4-10.2,2.8-15.1c6.2,7.1,4.3,7,8.6,18.2
+			c3.7,9.9,17.7,11.5,26.5,11.4c7.8-0.1,15.2-1,21-3.3c5-2,8.6-5,10.3-8.7C135.1,98.7,130.1,86.2,111.2,73z"/>
+		<path fill="#FDF3E7" d="M103.5,88.7c-1.7,0-3.4,0.7-4.6,2L74.1,77.6c0.3-0.9,0.4-1.9,0.4-2.8c0-4.4-3-8.4-7.3-9.5l1.8-24
+			c2.8-0.7,4.8-3.2,4.8-6.1c0-3.5-2.8-6.3-6.3-6.3c-3.5,0-6.3,2.8-6.3,6.3c0,2.7,1.6,5,4.1,5.9l-1.8,24c-4.9,0.6-8.6,4.8-8.6,9.7
+			c0,1.5,0.4,3,1,4.4L31.1,96.5c-1.1-0.9-2.5-1.4-3.9-1.4c-3.5,0-6.3,2.8-6.3,6.3s2.8,6.3,6.3,6.3s6.3-2.8,6.3-6.3
+			c0-0.6-0.1-1.3-0.3-1.9l24.9-17.4c1.8,1.6,4.1,2.5,6.5,2.5c3,0,5.8-1.4,7.7-3.7L97.3,94c-0.1,0.4-0.1,0.7-0.1,1
+			c0,3.5,2.8,6.3,6.3,6.3c3.5,0,6.3-2.8,6.3-6.3S107,88.7,103.5,88.7z"/>
+		<circle fill="#F6B771" cx="103.5" cy="95" r="3.5"/>
+		<circle fill="#F6B771" cx="67.5" cy="35.2" r="3.5"/>
+		<circle fill="#F6B771" cx="27.1" cy="101.4" r="3.5"/>
+		<circle fill="#F6B771" cx="64.7" cy="74.8" r="6.3"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
E.g. for use as Hono Helm chart icon (for example shown on https://artifacthub.io/packages/helm/eclipse-iot/hono).
The added file is copied from
logo/SVG-Tiny/HONO-Logo_Bild_s-135x125px.svg.