### PR TITLE
Update commit requirements in Contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,18 +15,18 @@ In order to get you started as fast as possible we need to go through some organ
 
 ## Eclipse Contributor Agreement
 
-Before your contribution can be accepted by the project team contributors must
+In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* http://www.eclipse.org/legal/ECA.php
+* https://www.eclipse.org/legal/ECA.php
 
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
 
-For more information, please see the Eclipse Committer Handbook:
+For more information, please see the Eclipse Project Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Making your Changes
@@ -41,7 +41,6 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 * Use descriptive and meaningful commit messages. In particular, start the first line of the commit message with the
   number of the issue that the commit addresses, e.g. `[#9865] Add token based authentication.`
 * Squash multiple commits that are related to each other semantically into a single one
-* Make sure you use the `-s` flag when committing as explained above
 * Push your changes to your branch in your forked repository
 
 ## Submitting the Changes

--- a/site/homepage/content/community/contributing.md
+++ b/site/homepage/content/community/contributing.md
@@ -24,18 +24,18 @@ You might also want to take a look at our [GitHub Issues](https://github.com/ecl
 
 ## Eclipse Contributor Agreement
 
-Before your contribution can be accepted by the project team contributors must
+In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* http://www.eclipse.org/legal/ECA.php
+* https://www.eclipse.org/legal/ECA.php
 
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
+The ECA provides the Eclipse Foundation with a permanent record that you agree
+that each of your contributions will comply with the commitments documented in
+the Developer Certificate of Origin (DCO). Having an ECA on file associated with
+the email address matching the "Author" field of your contribution's Git commits
+fulfills the DCO's requirement that you sign-off on your contributions.
 
-For more information, please see the Eclipse Committer Handbook:
+For more information, please see the Eclipse Project Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## Conventions
@@ -73,8 +73,7 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 9. Commit your changes into your *feature branch*.
 10. Use descriptive and meaningful commit messages.
 11. Squash multiple commits related to the same feature/issue into a single one, if reasonable.
-12. Make sure you use the `-s` flag when committing in order to add a *Signed-off-by* footer as mentioned above.
-13. Push your changes to your branch in your forked repository.
+12. Push your changes to your branch in your forked repository.
 
 ## Submitting the Changes
 


### PR DESCRIPTION
Removing the 'Signed-off-by' requirement as it isn't listed in the [Eclipse Project Handbook](https://www.eclipse.org/projects/handbook/#resources-commit) anymore.

See the corresponding change in the `org.eclipse.dash.handbook` repo [here](https://gitlab.eclipse.org/eclipse/technology/dash/org.eclipse.dash.handbook/-/commit/ba80975702f666de587e9cd0003d821cb8f95d9a#13e7b2e3a22176dcc2d2d157775b7732dff45899_91_88).