### PR TITLE
[#3547] Migrate to Quarkus 3.2.6.Final

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
@@ -19,8 +19,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.monitoring.ConnectionEventProducer;
 import org.eclipse.hono.adapter.monitoring.ConnectionEventProducerConfig;
 import org.eclipse.hono.adapter.monitoring.ConnectionEventProducerOptions;
@@ -104,6 +102,7 @@ import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
+import jakarta.inject.Inject;
 
 /**
  * A Quarkus main application base class for Hono protocol adapters.

--- a/adapters/amqp/pom.xml
+++ b/adapters/amqp/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -30,6 +30,14 @@
     <dependency>
       <groupId>org.eclipse.hono</groupId>
       <artifactId>hono-client-notification</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
 
     <!-- testing -->

--- a/adapters/amqp/src/main/java/org/eclipse/hono/adapter/amqp/app/Application.java
+++ b/adapters/amqp/src/main/java/org/eclipse/hono/adapter/amqp/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,13 +12,13 @@
  */
 package org.eclipse.hono.adapter.amqp.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.adapter.amqp.AmqpAdapterMetrics;
 import org.eclipse.hono.adapter.amqp.AmqpAdapterProperties;
 import org.eclipse.hono.adapter.amqp.VertxBasedAmqpProtocolAdapter;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Hono AMQP adapter main application class.

--- a/adapters/amqp/src/main/java/org/eclipse/hono/adapter/amqp/app/MetricsFactory.java
+++ b/adapters/amqp/src/main/java/org/eclipse/hono/adapter/amqp/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.adapter.amqp.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.amqp.AmqpAdapterOptions;
 import org.eclipse.hono.adapter.amqp.AmqpAdapterProperties;
 import org.eclipse.hono.adapter.amqp.MicrometerBasedAmqpAdapterMetrics;
@@ -25,6 +21,9 @@ import org.eclipse.hono.util.Constants;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates protocol adapter specific metrics.

--- a/adapters/amqp/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-amqp/native-image.properties
+++ b/adapters/amqp/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-amqp/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/adapters/coap/pom.xml
+++ b/adapters/coap/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -42,6 +42,14 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
 
   </dependencies>

--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/app/Application.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,6 @@ package org.eclipse.hono.adapter.coap.app;
 
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.adapter.coap.CoapAdapterMetrics;
 import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
@@ -30,6 +27,9 @@ import org.eclipse.hono.adapter.coap.impl.VertxBasedCoapAdapter;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.EventConstants;
 import org.eclipse.hono.util.TelemetryConstants;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Hono CoAP adapter main application class.

--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/app/MetricsFactory.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.adapter.coap.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.coap.CoapAdapterOptions;
 import org.eclipse.hono.adapter.coap.CoapAdapterProperties;
 import org.eclipse.hono.adapter.coap.MicrometerBasedCoapAdapterMetrics;
@@ -25,6 +21,9 @@ import org.eclipse.hono.util.Constants;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates protocol adapter specific metrics.

--- a/adapters/coap/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-coap/native-image.properties
+++ b/adapters/coap/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-coap/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/adapters/http/pom.xml
+++ b/adapters/http/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -32,6 +32,14 @@
       <artifactId>hono-adapter-http-base</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.enterprise</groupId>
+      <artifactId>jakarta.enterprise.cdi-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/adapters/http/src/main/java/org/eclipse/hono/adapter/http/app/Application.java
+++ b/adapters/http/src/main/java/org/eclipse/hono/adapter/http/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,13 +12,13 @@
  */
 package org.eclipse.hono.adapter.http.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.impl.VertxBasedHttpProtocolAdapter;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Hono HTTP adapter main application class.

--- a/adapters/http/src/main/java/org/eclipse/hono/adapter/http/app/MetricsFactory.java
+++ b/adapters/http/src/main/java/org/eclipse/hono/adapter/http/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.adapter.http.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterOptions;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.MicrometerBasedHttpAdapterMetrics;
@@ -25,6 +21,9 @@ import org.eclipse.hono.util.Constants;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates protocol adapter specific metrics.

--- a/adapters/http/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-http/native-image.properties
+++ b/adapters/http/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-http/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/adapters/lora/pom.xml
+++ b/adapters/lora/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -51,6 +51,10 @@
     <dependency>
        <groupId>jakarta.enterprise</groupId>
        <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
     </dependency>
 
     <!-- testing -->

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/app/Application.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,10 +15,6 @@ package org.eclipse.hono.adapter.lora.app;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
@@ -27,6 +23,9 @@ import org.eclipse.hono.adapter.lora.LoraProtocolAdapter;
 import org.eclipse.hono.adapter.lora.providers.LoraProvider;
 
 import io.vertx.ext.web.client.WebClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 
 /**
  * The Hono Lora adapter main application class.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/app/LoraCommandSubscriptionsFactory.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/app/LoraCommandSubscriptionsFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,14 +13,13 @@
 
 package org.eclipse.hono.adapter.lora.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.lora.LoraCommandSubscriptions;
 
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates Lora adapter command subscriptions class. It'll always be a {@link Singleton}.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/app/MetricsFactory.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.adapter.lora.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterOptions;
 import org.eclipse.hono.adapter.http.HttpProtocolAdapterProperties;
 import org.eclipse.hono.adapter.http.MicrometerBasedHttpAdapterMetrics;
@@ -26,6 +22,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.smallrye.config.ConfigMapping;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates protocol adapter specific metrics.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ActilityEnterpriseProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ActilityEnterpriseProvider.java
@@ -16,13 +16,12 @@ package org.eclipse.hono.adapter.lora.providers;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Actility Enterprise.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ActilityWirelessProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ActilityWirelessProvider.java
@@ -16,13 +16,12 @@ package org.eclipse.hono.adapter.lora.providers;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Actility Wireless.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ChirpStackProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ChirpStackProvider.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -29,6 +27,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for ChirpStack.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ChirpStackV4Provider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ChirpStackV4Provider.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -31,6 +29,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for ChirpStack v4.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/EverynetProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/EverynetProvider.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -28,6 +26,7 @@ import org.eclipse.hono.service.http.HttpUtils;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Everynet.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/FireflyProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/FireflyProvider.java
@@ -16,8 +16,6 @@ package org.eclipse.hono.adapter.lora.providers;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -27,6 +25,7 @@ import com.google.common.io.BaseEncoding;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Firefly.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/KerlinkProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/KerlinkProvider.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -29,6 +27,7 @@ import com.google.common.io.BaseEncoding;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Kerlink.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderCustomContentType.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/KerlinkProviderCustomContentType.java
@@ -17,12 +17,11 @@ import java.util.Base64;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Kerlink.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/LiveObjectsProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/LiveObjectsProvider.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
 import org.eclipse.hono.util.MessageHelper;
@@ -29,6 +27,7 @@ import com.google.common.io.BaseEncoding;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for LiveObjectsProvider.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/LoriotProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/LoriotProvider.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -35,6 +33,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Loriot.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/MultiTechProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/MultiTechProvider.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -28,6 +26,7 @@ import org.eclipse.hono.util.MessageHelper;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for MultiTechProvider.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ObjeniousProvider.java
@@ -17,8 +17,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -27,6 +25,7 @@ import com.google.common.io.BaseEncoding;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Objenious.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/OrbiwiseProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/OrbiwiseProvider.java
@@ -17,8 +17,6 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -28,6 +26,7 @@ import com.google.common.io.BaseEncoding;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Orbiwise.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ProximusProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ProximusProvider.java
@@ -17,8 +17,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -27,6 +25,7 @@ import com.google.common.io.BaseEncoding;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Proximus.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/TheThingsStackProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/TheThingsStackProvider.java
@@ -18,8 +18,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -29,6 +27,7 @@ import com.google.common.io.BaseEncoding;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for The Thing Stack.

--- a/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProvider.java
+++ b/adapters/lora/src/main/java/org/eclipse/hono/adapter/lora/providers/ThingsNetworkProvider.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.adapter.lora.GatewayInfo;
 import org.eclipse.hono.adapter.lora.LoraMessageType;
 import org.eclipse.hono.adapter.lora.LoraMetaData;
@@ -31,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A LoRaWAN provider with API for Things Network.

--- a/adapters/lora/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-lora/native-image.properties
+++ b/adapters/lora/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-lora/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/adapters/mqtt/src/main/java/org/eclipse/hono/adapter/mqtt/app/Application.java
+++ b/adapters/mqtt/src/main/java/org/eclipse/hono/adapter/mqtt/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,9 +12,6 @@
  */
 package org.eclipse.hono.adapter.mqtt.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.adapter.mqtt.MessageMapping;
 import org.eclipse.hono.adapter.mqtt.MqttAdapterMetrics;
@@ -24,6 +21,8 @@ import org.eclipse.hono.adapter.mqtt.impl.HttpBasedMessageMapping;
 import org.eclipse.hono.adapter.mqtt.impl.VertxBasedMqttProtocolAdapter;
 
 import io.vertx.ext.web.client.WebClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Hono MQTT adapter main application class.

--- a/adapters/mqtt/src/main/java/org/eclipse/hono/adapter/mqtt/app/MetricsFactory.java
+++ b/adapters/mqtt/src/main/java/org/eclipse/hono/adapter/mqtt/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.adapter.mqtt.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.mqtt.MicrometerBasedMqttAdapterMetrics;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterOptions;
 import org.eclipse.hono.adapter.mqtt.MqttProtocolAdapterProperties;
@@ -25,6 +21,9 @@ import org.eclipse.hono.util.Constants;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates protocol adapter specific metrics.

--- a/adapters/mqtt/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-mqtt/native-image.properties
+++ b/adapters/mqtt/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-mqtt/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/adapters/parent/pom.xml
+++ b/adapters/parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -240,6 +240,7 @@ hono.kafka.commandResponse.producerConfig."request.timeout.ms"=${kafka-client.pr
                       <assembly>
                         <mode>dir</mode>
                         <basedir>/</basedir>
+                        <permissions>auto</permissions>
                         <inline>
                           <fileSets>
                             <fileSet>

--- a/adapters/sigfox/src/main/java/org/eclipse/hono/adapter/sigfox/app/Application.java
+++ b/adapters/sigfox/src/main/java/org/eclipse/hono/adapter/sigfox/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,13 +12,13 @@
  */
 package org.eclipse.hono.adapter.sigfox.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.adapter.AbstractProtocolAdapterApplication;
 import org.eclipse.hono.adapter.http.HttpAdapterMetrics;
 import org.eclipse.hono.adapter.sigfox.impl.SigfoxProtocolAdapter;
 import org.eclipse.hono.adapter.sigfox.impl.SigfoxProtocolAdapterProperties;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Hono Sigfox adapter main application class.

--- a/adapters/sigfox/src/main/java/org/eclipse/hono/adapter/sigfox/app/MetricsFactory.java
+++ b/adapters/sigfox/src/main/java/org/eclipse/hono/adapter/sigfox/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.adapter.sigfox.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.adapter.http.MicrometerBasedHttpAdapterMetrics;
 import org.eclipse.hono.adapter.sigfox.impl.SigfoxProtocolAdapterOptions;
 import org.eclipse.hono.adapter.sigfox.impl.SigfoxProtocolAdapterProperties;
@@ -25,6 +21,9 @@ import org.eclipse.hono.util.Constants;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates protocol adapter specific metrics.

--- a/adapters/sigfox/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-sigfox/native-image.properties
+++ b/adapters/sigfox/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-adapter-sigfox/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,30 +30,27 @@
   <properties>
     <artemis.image.name>quay.io/artemiscloud/activemq-artemis-broker:1.0.6</artemis.image.name>
     <assertj.version>3.24.2</assertj.version>
-    <bouncycastle.version>1.71</bouncycastle.version>
     <californium.version>3.9.1</californium.version>
     <cryptvault.version>1.0.2</cryptvault.version>
     <dispatch-router.image.name>quay.io/interconnectedcloud/qdrouterd:1.17.1</dispatch-router.image.name>
     <guava.version>32.1.2-jre</guava.version>
+    <infinispan.version>14.0.11.Final</infinispan.version>
     <infinispan-image.name>quay.io/infinispan/server-native:13.0.12.Final</infinispan-image.name>
     <jaeger.image.name>docker.io/jaegertracing/all-in-one:1.45</jaeger.image.name>
-    <jakarta.jaxrs-api.version>2.1.6</jakarta.jaxrs-api.version>
+    <javax.transaction-api.version>1.3</javax.transaction-api.version>
     <java-base-image.name>docker.io/library/eclipse-temurin:17-jre-jammy</java-base-image.name>
     <jjwt.version>0.11.5</jjwt.version>
-    <kafka-client.version>3.3.2</kafka-client.version>
     <kafka.image.name>docker.io/confluentinc/cp-kafka:7.3.5</kafka.image.name>
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.4.11</logback.version>
     <mongodb-image.name>docker.io/library/mongo:4.4</mongodb-image.name>
     <native.image.name>quay.io/quarkus/quarkus-micro-image:2.0</native.image.name>
     <native.builder-image.name>mandrel</native.builder-image.name>
-    <netty.version>4.1.94.Final</netty.version>
     <postgresql-image.name>docker.io/library/postgres:14-alpine</postgresql-image.name>
     <qpid-jms.version>1.10.0</qpid-jms.version>
-    <quarkus.platform.version>2.16.9.Final</quarkus.platform.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <quarkus.platform.version>3.2.6.Final</quarkus.platform.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <spring-security-crypto.version>6.1.4</spring-security-crypto.version>
     <truth.version>1.1.3</truth.version>
-    <vertx.version>4.3.7</vertx.version>
     <zookeeper.image.name>docker.io/confluentinc/cp-zookeeper:7.3.5</zookeeper.image.name>
 
     <!-- The port at which the health check server should expose its resources -->
@@ -81,8 +78,6 @@ quarkus.micrometer.binder.kafka.enabled=false
 quarkus.micrometer.binder.system=true
 quarkus.micrometer.binder.vertx.enabled=true
 quarkus.micrometer.export.prometheus.path=/prometheus
-# Hono custom Sampler shall not be wrapped by parent-based Sampler
-quarkus.opentelemetry.tracer.sampler.parent-based=false
 quarkus.smallrye-health.root-path=${health.check.root-path}
 quarkus.smallrye-health.liveness-path=${health.check.liveness-path}
 quarkus.smallrye-health.readiness-path=${health.check.readiness-path}
@@ -193,7 +188,6 @@ quarkus.devservices.enabled=false
 # app id
 quarkus.application.name=${app.id}
 # Log setup
-quarkus.log.console.color=true
 quarkus.log.level=INFO
 quarkus.log.category."io.quarkus.vertx.core.runtime".level=DEBUG
 quarkus.log.category."org.eclipse.hono".level=${hono.debug.level:INFO}
@@ -500,108 +494,6 @@ quarkus.vertx.max-event-loop-execute-time=${max.event-loop.execute-time:20000}
         <version>${spring-security-crypto.version}</version>
       </dependency>
 
-      <!-- vert.x -->
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-core</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-proton</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-mqtt</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-bridge-common</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web-common</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web-client</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-auth-common</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-auth-jdbc</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-health-check</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-micrometer-metrics</artifactId>
-        <version>${vertx.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-jdbc-client</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-auth-mongo</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-mongo-client</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-kafka-client</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${kafka-client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-codegen</artifactId>
-        <version>${vertx.version}</version>
-      </dependency>
-
-      <!-- Netty dependencies, imported as a BOM -->
-      <dependency>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-bom</artifactId>
-          <version>${netty.version}</version>
-          <type>pom</type>
-          <scope>import</scope>
-      </dependency>
-
       <!-- Logging -->
       <dependency>
         <groupId>ch.qos.logback</groupId>
@@ -611,26 +503,8 @@ quarkus.vertx.max-event-loop-execute-time=${max.event-loop.execute-time:20000}
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>runtime</scope>
       </dependency>
 
       <!-- Other -->
@@ -699,9 +573,25 @@ quarkus.vertx.max-event-loop-execute-time=${max.event-loop.execute-time:20000}
         <version>${cryptvault.version}</version>
       </dependency>
       <dependency>
-        <groupId>jakarta.ws.rs</groupId>
-        <artifactId>jakarta.ws.rs-api</artifactId>
-        <version>${jakarta.jaxrs-api.version}</version>
+        <groupId>javax.transaction</groupId>
+        <artifactId>javax.transaction-api</artifactId>
+        <version>${javax.transaction-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>${infinispan.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-client-hotrod</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+          </exclusion>
+        </exclusions>
+        <version>${infinispan.version}</version>
       </dependency>
 
       <!-- Testing -->
@@ -733,18 +623,6 @@ quarkus.vertx.max-event-loop-execute-time=${max.event-loop.execute-time:20000}
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>${qpid-jms.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk18on</artifactId>
-        <version>${bouncycastle.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-junit5</artifactId>
-        <version>${vertx.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -103,7 +103,6 @@
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
-      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.juniversalchardet</groupId>

--- a/cli/src/main/java/org/eclipse/hono/cli/CustomConfiguration.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/CustomConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,13 +14,12 @@
 
 package org.eclipse.hono.cli;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-
 import org.eclipse.hono.cli.util.CommandUtils;
 import org.eclipse.hono.client.ServiceInvocationException;
 
 import io.quarkus.picocli.runtime.PicocliCommandLineFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 import picocli.CommandLine;
 
 /**

--- a/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,10 +25,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.cli.util.ClientCertInfo;
@@ -66,6 +62,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.ParameterException;

--- a/cli/src/main/java/org/eclipse/hono/cli/app/CommandAndControl.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/CommandAndControl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,8 +25,6 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-import javax.inject.Singleton;
-
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.cli.util.CommandUtils;
 import org.eclipse.hono.cli.util.IntegerVariableConverter;
@@ -50,6 +48,7 @@ import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 
 import io.vertx.core.buffer.Buffer;
+import jakarta.inject.Singleton;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 import picocli.shell.jline3.PicocliCommands;

--- a/cli/src/main/java/org/eclipse/hono/cli/app/NorthBoundApis.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/NorthBoundApis.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,10 +16,6 @@ package org.eclipse.hono.cli.app;
 
 import java.util.HashMap;
 import java.util.Optional;
-
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
@@ -48,6 +44,9 @@ import io.quarkus.runtime.ShutdownEvent;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.ParameterException;

--- a/cli/src/main/java/org/eclipse/hono/cli/app/TelemetryAndEvent.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/TelemetryAndEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,9 +22,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionException;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.application.client.ApplicationClient;
 import org.eclipse.hono.application.client.DownstreamMessage;
 import org.eclipse.hono.application.client.MessageContext;
@@ -38,6 +35,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 import picocli.CommandLine;
 import picocli.CommandLine.ScopeType;
 

--- a/cli/src/main/java/org/eclipse/hono/cli/util/ConnectionOptions.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/util/ConnectionOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,7 @@ package org.eclipse.hono.cli.util;
 
 import java.util.Optional;
 
-import javax.inject.Singleton;
-
+import jakarta.inject.Singleton;
 import picocli.CommandLine;
 
 /**

--- a/client-device-connection-infinispan/pom.xml
+++ b/client-device-connection-infinispan/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2019, 2023 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -135,6 +135,15 @@
       <groupId>org.eclipse.hono</groupId>
       <artifactId>core-test-utils</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaClientMetricsSupportProducer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/metrics/KafkaClientMetricsSupportProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,9 +15,9 @@ package org.eclipse.hono.client.kafka.metrics;
 
 import java.util.List;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of an implementation to provide support for registering Kafka clients from which metrics are fetched.

--- a/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/ConfigurationProducer.java
+++ b/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/ConfigurationProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,13 +14,6 @@
 
 package org.eclipse.hono.example.protocolgateway;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Dependent;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
 import org.eclipse.hono.client.amqp.config.ClientOptions;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
@@ -30,6 +23,12 @@ import org.eclipse.hono.util.Constants;
 
 import io.smallrye.config.ConfigMapping;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 /**
  * Example TCP server to send event and telemetry messages to Hono AMQP adapter and receive commands.

--- a/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/TcpServer.java
+++ b/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/TcpServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,9 +15,6 @@ package org.eclipse.hono.example.protocolgateway;
 
 import java.util.Optional;
 
-import javax.enterprise.context.Dependent;
-import javax.inject.Inject;
-
 import org.eclipse.hono.config.ServerConfig;
 import org.eclipse.hono.config.ServerOptions;
 import org.slf4j.Logger;
@@ -30,6 +27,8 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.NetServer;
 import io.vertx.core.net.NetSocket;
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
 
 /**
  * The TCP server that devices connect to.

--- a/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/controller/ProtocolGateway.java
+++ b/examples/protocol-gateway-example/src/main/java/org/eclipse/hono/example/protocolgateway/controller/ProtocolGateway.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,10 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import javax.enterprise.context.Dependent;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.apache.qpid.proton.message.Message;
 import org.eclipse.hono.client.amqp.connection.AmqpUtils;
 import org.eclipse.hono.client.command.CommandConsumer;
@@ -47,6 +43,9 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.net.NetSocket;
 import io.vertx.core.parsetools.RecordParser;
 import io.vertx.proton.ProtonDelivery;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 
 /**
  * Example protocol gateway service to send messages to Hono's AMQP adapter.

--- a/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceApplication.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/AbstractServiceApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,9 +20,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.health.Readiness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +33,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.impl.cpu.CpuCoreSensor;
 import io.vertx.core.json.impl.JsonUtil;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 
 /**
  * A base class for implementing Quarkus based services.

--- a/service-base/src/main/java/org/eclipse/hono/service/ApplicationPropertiesProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/ApplicationPropertiesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,9 @@
 
 package org.eclipse.hono.service;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of {@link ApplicationConfigProperties}.

--- a/service-base/src/main/java/org/eclipse/hono/service/DeploymentHealthCheck.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/DeploymentHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,15 +20,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
-
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A health check that tracks the deployment of Verticles.

--- a/service-base/src/main/java/org/eclipse/hono/service/SmallRyeHealthCheckServer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/SmallRyeHealthCheckServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,8 +18,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
 import org.eclipse.microprofile.health.Readiness;
@@ -35,7 +33,7 @@ import io.vertx.ext.healthchecks.CheckResult;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.Status;
 import io.vertx.ext.web.RoutingContext;
-
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * A SmallRye Health based {@link HealthCheckServer} that adapts Vert.x Health Checks to MicroProfile Health checks.

--- a/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/quarkus/DelegatingAuthenticationServiceProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/auth/delegating/quarkus/DelegatingAuthenticationServiceProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,10 +13,6 @@
 
 
 package org.eclipse.hono.service.auth.delegating.quarkus;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
 
 import org.eclipse.hono.client.amqp.connection.ConnectionFactory;
 import org.eclipse.hono.service.auth.AuthenticationService;
@@ -35,6 +31,9 @@ import io.smallrye.config.ConfigMapping;
 import io.smallrye.health.api.HealthRegistry;
 import io.vertx.core.Vertx;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of an application scoped {@link AuthenticationService} which delegates

--- a/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/metric/MicrometerBasedMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -294,7 +294,7 @@ public class MicrometerBasedMetrics implements Metrics, SendMessageSampler.Facto
         // record payload size
         DistributionSummary.builder(METER_TELEMETRY_PAYLOAD)
             .baseUnit("bytes")
-            .minimumExpectedValue(0.0)
+            .minimumExpectedValue(0.01)
             .tags(tags)
             .register(this.registry)
             .record(ServiceBaseUtils.calculatePayloadSize(payloadSize, tenantObject));
@@ -329,7 +329,7 @@ public class MicrometerBasedMetrics implements Metrics, SendMessageSampler.Facto
         // record payload size
         DistributionSummary.builder(METER_COMMAND_PAYLOAD)
             .baseUnit("bytes")
-            .minimumExpectedValue(0.0)
+            .minimumExpectedValue(0.01)
             .tags(tags)
             .register(this.registry)
             .record((double) ServiceBaseUtils.calculatePayloadSize(payloadSize, tenantObject));

--- a/service-base/src/main/java/org/eclipse/hono/service/tracing/TracerProducer.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/tracing/TracerProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,13 +12,12 @@
  */
 package org.eclipse.hono.service.tracing;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentracing.Tracer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer for an OpenTracing Tracer.

--- a/services/auth-base/src/main/java/org/eclipse/hono/authentication/JwkResource.java
+++ b/services/auth-base/src/main/java/org/eclipse/hono/authentication/JwkResource.java
@@ -16,16 +16,15 @@ package org.eclipse.hono.authentication;
 
 import java.util.Objects;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-
 import org.eclipse.hono.service.auth.AuthTokenFactory;
 import org.eclipse.hono.service.auth.delegating.AuthenticationServerClientOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.vertx.core.buffer.Buffer;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 /**
  * A resource for retrieving a JSON Web Key set that contains the (public) key that clients

--- a/services/auth/pom.xml
+++ b/services/auth/pom.xml
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
    
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -47,6 +47,10 @@
     <dependency>
      <groupId>org.eclipse.hono</groupId>
      <artifactId>hono-client-amqp-connection</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/services/auth/src/main/java/org/eclipse/hono/authentication/app/Application.java
+++ b/services/auth/src/main/java/org/eclipse/hono/authentication/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,6 @@ package org.eclipse.hono.authentication.app;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 import org.eclipse.hono.authentication.AuthenticationEndpoint;
 import org.eclipse.hono.authentication.AuthenticationServerMetrics;
@@ -39,6 +36,8 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Quarkus based Authentication server main application class.

--- a/services/auth/src/main/java/org/eclipse/hono/authentication/app/MeterFilterProducer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/authentication/app/MeterFilterProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,13 @@
 
 package org.eclipse.hono.authentication.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
 
 import io.micrometer.core.instrument.config.MeterFilter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory for {@code MeterFilter}s.

--- a/services/auth/src/main/java/org/eclipse/hono/authentication/app/PropertiesProducer.java
+++ b/services/auth/src/main/java/org/eclipse/hono/authentication/app/PropertiesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,10 +14,6 @@
 
 package org.eclipse.hono.authentication.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.authentication.file.FileBasedAuthenticationServiceConfigProperties;
 import org.eclipse.hono.authentication.file.FileBasedAuthenticationServiceOptions;
 import org.eclipse.hono.config.ServiceConfigProperties;
@@ -27,6 +23,9 @@ import org.eclipse.hono.service.auth.JjwtBasedAuthTokenFactory;
 
 import io.smallrye.config.ConfigMapping;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer for the Authentication Server's JWK resource.

--- a/services/auth/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-auth/native-image.properties
+++ b/services/auth/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-auth/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/StatementTest.java
+++ b/services/base-jdbc/src/test/java/org/eclipse/hono/service/base/jdbc/store/StatementTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.yaml.snakeyaml.constructor.ConstructorException;
+import org.yaml.snakeyaml.composer.ComposerException;
 
 /**
  * Testing {@link Statement}.
@@ -132,7 +132,7 @@ public class StatementTest {
 
         assertFalse(Files.isRegularFile(markerFile), "Marker file must not exist");
         assertNotNull(expected);
-        assertThat(expected).isInstanceOf(ConstructorException.class);
+        assertThat(expected).isInstanceOf(ComposerException.class);
     }
 
 }

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/Application.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/Application.java
@@ -16,9 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
 import org.eclipse.hono.client.amqp.config.ClientOptions;
 import org.eclipse.hono.client.amqp.config.RequestResponseClientConfigProperties;
@@ -90,6 +87,8 @@ import io.vertx.core.Verticle;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * The Quarkus based Command Router main application class.

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/DeviceConnectionInfoProducer.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/DeviceConnectionInfoProducer.java
@@ -19,10 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.commandrouter.AdapterInstanceStatusService;
 import org.eclipse.hono.commandrouter.CommandRouterServiceOptions;
 import org.eclipse.hono.commandrouter.impl.KubernetesBasedAdapterInstanceStatusService;
@@ -48,6 +44,9 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Tracer;
 import io.smallrye.config.ConfigMapping;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of an application scoped {@link DeviceConnectionInfo} instance.

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/MetricsFactory.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/MetricsFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 package org.eclipse.hono.commandrouter.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.commandrouter.MicrometerBasedCommandRouterMetrics;
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
@@ -23,6 +19,9 @@ import org.eclipse.hono.util.Constants;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory class that creates Command Router specific metrics.

--- a/services/command-router/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-command-router/native-image.properties
+++ b/services/command-router/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-command-router/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractAmqpServerFactory.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractAmqpServerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,10 +12,6 @@
  */
 
 package org.eclipse.hono.deviceregistry.app;
-
-
-import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
@@ -58,6 +54,8 @@ import io.smallrye.config.ConfigMapping;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 /**
  * A factory base class for creating AMQP 1.0 based endpoints of Hono's south bound APIs.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractDeviceRegistryApplication.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractDeviceRegistryApplication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,8 +16,6 @@ package org.eclipse.hono.deviceregistry.app;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.inject.Inject;
-
 import org.eclipse.hono.notification.NotificationSender;
 import org.eclipse.hono.service.AbstractServiceApplication;
 import org.eclipse.hono.service.auth.AuthenticationService;
@@ -29,6 +27,7 @@ import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
+import jakarta.inject.Inject;
 
 /**
  * A base class for the device registry main application class.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractHttpServerFactory.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractHttpServerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,8 +12,6 @@
  */
 
 package org.eclipse.hono.deviceregistry.app;
-
-import javax.inject.Inject;
 
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
 import org.eclipse.hono.service.HealthCheckServer;
@@ -28,6 +26,7 @@ import org.eclipse.hono.service.management.tenant.TenantManagementService;
 
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
+import jakarta.inject.Inject;
 
 /**
  * A factory base class for creating Device Registry Management API endpoints.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/CommonConfigPropertiesProducer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/CommonConfigPropertiesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,11 +13,6 @@
 
 package org.eclipse.hono.deviceregistry.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
 import org.eclipse.hono.client.amqp.config.ClientOptions;
 import org.eclipse.hono.client.kafka.CommonKafkaClientOptions;
@@ -30,6 +25,10 @@ import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigOptio
 import org.eclipse.hono.deviceregistry.service.device.AutoProvisionerConfigProperties;
 
 import io.smallrye.config.ConfigMapping;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of registry service configuration properties commonly used in registry implementations.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/MeterFilterProducer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/MeterFilterProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,14 +14,13 @@
 
 package org.eclipse.hono.deviceregistry.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.service.metric.MetricsTags;
 import org.eclipse.hono.util.Constants;
 
 import io.micrometer.core.instrument.config.MeterFilter;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A factory for {@code MeterFilter}s.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/NotificationSenderProducer.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/NotificationSenderProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,12 +14,6 @@
 package org.eclipse.hono.deviceregistry.app;
 
 import java.util.Optional;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
 
 import org.eclipse.hono.client.amqp.config.ClientConfigProperties;
 import org.eclipse.hono.client.amqp.connection.HonoConnection;
@@ -47,6 +41,11 @@ import com.google.api.gax.core.CredentialsProvider;
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 
 /**
  * Creates a client for publishing notifications using the configured messaging infrastructure.

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/metrics/DeviceRegistryMetricsAdapter.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/metrics/DeviceRegistryMetricsAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,9 +16,6 @@ package org.eclipse.hono.deviceregistry.metrics;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +23,8 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.Future;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 
 /**
  * A base class for implementing device registry metrics.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/AmqpServerFactory.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/AmqpServerFactory.java
@@ -14,9 +14,6 @@
 
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.deviceregistry.app.AbstractAmqpServerFactory;
 import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceOptions;
 import org.eclipse.hono.deviceregistry.jdbc.config.SchemaCreator;
@@ -27,6 +24,9 @@ import org.eclipse.hono.deviceregistry.jdbc.impl.TenantServiceImpl;
 import org.eclipse.hono.service.base.jdbc.store.device.TableAdapterStore;
 import org.eclipse.hono.service.base.jdbc.store.tenant.AdapterStore;
 import org.eclipse.hono.service.tenant.TenantService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * A factory for creating AMQP 1.0 based endpoints of Hono's south bound APIs.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/Application.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/Application.java
@@ -12,9 +12,9 @@
  */
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.deviceregistry.app.AbstractDeviceRegistryApplication;
+
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * The Quarkus based JDBC registry main application class.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ConfigPropertiesProducer.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ConfigPropertiesProducer.java
@@ -14,14 +14,14 @@
 
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreOptions;
 import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreProperties;
 import org.eclipse.hono.service.base.jdbc.config.JdbcTenantStoreOptions;
 import org.eclipse.hono.service.base.jdbc.config.JdbcTenantStoreProperties;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of registry service configuration properties.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/HttpServerFactory.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/HttpServerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,14 +13,13 @@
 
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.deviceregistry.app.AbstractHttpServerFactory;
 import org.eclipse.hono.service.http.HttpServiceConfigOptions;
 import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 
 import io.smallrye.config.ConfigMapping;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * A factory for creating Device Registry Management API endpoints.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/JdbcBasedDeviceRegistryMetrics.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/JdbcBasedDeviceRegistryMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,13 +13,12 @@
 
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.deviceregistry.metrics.DeviceRegistryMetricsAdapter;
 import org.eclipse.hono.service.base.jdbc.store.tenant.ManagementStore;
 
 import io.vertx.core.Future;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Metrics reported by the registry.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ManagementServicesProducer.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ManagementServicesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,11 +13,6 @@
 
 
 package org.eclipse.hono.deviceregistry.jdbc.app;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceOptions;
 import org.eclipse.hono.deviceregistry.jdbc.impl.CredentialsManagementServiceImpl;
@@ -34,6 +29,10 @@ import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of the service instances implementing Hono's Device Registry Management API.

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/StoreProducer.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/StoreProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,11 +16,6 @@ package org.eclipse.hono.deviceregistry.jdbc.app;
 
 import java.io.IOException;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.deviceregistry.jdbc.config.SchemaCreator;
 import org.eclipse.hono.deviceregistry.jdbc.impl.ClasspathSchemaCreator;
 import org.eclipse.hono.service.HealthCheckServer;
@@ -35,6 +30,10 @@ import org.eclipse.hono.service.base.jdbc.store.tenant.Stores;
 
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of data store objects for registry data.

--- a/services/device-registry-jdbc/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-device-registry-jdbc/native-image.properties
+++ b/services/device-registry-jdbc/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-device-registry-jdbc/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/AmqpServerFactory.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/AmqpServerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,9 +14,6 @@
 
 package org.eclipse.hono.deviceregistry.mongodb.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.deviceregistry.app.AbstractAmqpServerFactory;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
@@ -29,6 +26,9 @@ import org.eclipse.hono.deviceregistry.mongodb.service.MongoDbBasedTenantService
 import org.eclipse.hono.deviceregistry.service.credentials.AbstractCredentialsService;
 import org.eclipse.hono.deviceregistry.service.device.AbstractRegistrationService;
 import org.eclipse.hono.service.tenant.TenantService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * A factory for creating AMQP 1.0 based endpoints of Hono's south bound APIs.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/Application.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,9 +12,9 @@
  */
 package org.eclipse.hono.deviceregistry.mongodb.app;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.eclipse.hono.deviceregistry.app.AbstractDeviceRegistryApplication;
+
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * The Quarkus based Mongo DB registry main application class.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ConfigPropertiesProducer.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ConfigPropertiesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,16 +13,16 @@
 
 package org.eclipse.hono.deviceregistry.mongodb.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of registry service configuration properties.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/DaoProducer.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/DaoProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,11 +18,6 @@ import java.io.FileInputStream;
 import java.util.Base64;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigOptions;
@@ -37,6 +32,7 @@ import org.eclipse.hono.deviceregistry.mongodb.model.TenantDao;
 import org.eclipse.hono.deviceregistry.util.CryptVaultBasedFieldLevelEncryption;
 import org.eclipse.hono.deviceregistry.util.FieldLevelEncryption;
 import org.eclipse.hono.service.HealthCheckServer;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 
@@ -48,6 +44,10 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
 import io.vertx.ext.mongo.MongoClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of Data Access Objects for registry data.
@@ -154,7 +154,7 @@ public class DaoProducer {
                     """)
     private FieldLevelEncryption fieldLevelEncryption(final String path) {
         try (FileInputStream in = new FileInputStream(path)) {
-            final Yaml yaml = new Yaml(new Constructor(CryptVaultConfigurationProperties.class));
+            final Yaml yaml = new Yaml(new Constructor(CryptVaultConfigurationProperties.class, new LoaderOptions()));
             final CryptVaultConfigurationProperties config = yaml.load(in);
             final CryptVault cryptVault = new CryptVault();
             for (CryptVaultAutoConfiguration.Key key : config.getKeys()) {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/HttpServerFactory.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/HttpServerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,9 +16,6 @@ package org.eclipse.hono.deviceregistry.mongodb.app;
 
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.deviceregistry.app.AbstractHttpServerFactory;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigProperties;
@@ -32,6 +29,8 @@ import io.vertx.ext.auth.mongo.impl.DefaultHashStrategy;
 import io.vertx.ext.auth.mongo.impl.MongoAuthenticationImpl;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.ext.web.handler.BasicAuthHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * A factory for creating Device Registry Management API endpoints.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ManagementServicesProducer.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ManagementServicesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,11 +13,6 @@
 
 
 package org.eclipse.hono.deviceregistry.mongodb.app;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
@@ -36,6 +31,10 @@ import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
 
 import io.vertx.core.Vertx;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
 
 /**
  * A producer of the service instances implementing Hono's Device Registry Management API.

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/MongoDbBasedDeviceRegistryMetrics.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/MongoDbBasedDeviceRegistryMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -13,14 +13,13 @@
 
 package org.eclipse.hono.deviceregistry.mongodb.app;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.hono.deviceregistry.metrics.DeviceRegistryMetricsAdapter;
 import org.eclipse.hono.deviceregistry.mongodb.model.TenantDao;
 
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Metrics reported by the registry.

--- a/services/device-registry-mongodb/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-device-registry-mongodb/native-image.properties
+++ b/services/device-registry-mongodb/src/main/resources/META-INF/native-image/org.eclipse.hono/hono-service-device-registry-mongodb/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:+RunReachabilityHandlersConcurrently

--- a/services/parent/pom.xml
+++ b/services/parent/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -71,7 +71,6 @@
       <groupId>org.jboss.logging</groupId>
       <artifactId>commons-logging-jboss-logging</artifactId>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -238,6 +237,7 @@
                       <assembly>
                         <mode>dir</mode>
                         <basedir>/</basedir>
+                        <permissions>auto</permissions>
                         <inline>
                           <fileSets>
                             <fileSet>

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -100,11 +100,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -99,11 +99,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -83,11 +83,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -77,11 +77,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
@@ -67,11 +67,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
@@ -77,11 +77,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -65,11 +65,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -93,11 +93,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/lora/application.yml
+++ b/tests/src/test/resources/lora/application.yml
@@ -90,11 +90,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -91,11 +91,10 @@ hono:
         delivery.timeout.ms: ${kafka-client.producer.delivery-timeout-ms}
 
 quarkus:
-  opentelemetry:
-    tracer:
-      exporter:
-        otlp:
-          endpoint: "${otel-collector.endpoint}"
+  otel:
+    exporter:
+      otlp:
+        endpoint: "${otel-collector.endpoint}"
   log:
     console:
       color: true


### PR DESCRIPTION
This PR is still slightly in progress.

1. Increased Quarkus version to 3.2.6.Final
2. Fixed all errors so that following normal image build and push succeeds:
```
mvn clean install -Pbuild-docker-image,metrics-prometheus,docker-push-image -Ddocker.*.details for harrismatt repository
```
3. Ran integration tests successfully with previous step images:
```
mvn verify -Prun-tests -Dhono.deviceregistry.type=file -Ddocker.image.org-name=harrismatt
```

Native image build is totally untested yet but there is so many changes already I think it's better make a PR now.

Please keep me posted on any improvements there might be and questions too.