### PR TITLE
Make HonoKafkaConsumer compatible with Kafka 3.5

### DIFF
--- a/clients/kafka-common/pom.xml
+++ b/clients/kafka-common/pom.xml
@@ -116,6 +116,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.hono</groupId>
+      <artifactId>core-test-utils</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.hono</groupId>
       <artifactId>kafka-test-utils</artifactId>
       <scope>test</scope>
     </dependency>

--- a/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/JUnitTests.java
+++ b/test-utils/core-test-utils/src/main/java/org/eclipse/hono/test/JUnitTests.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.hono.test;
+
+
+/**
+ * Utility methods for implementing JUnit tests.
+ */
+public final class JUnitTests {
+
+    /**
+     * Pattern used for the <em>name</em> field of the {@code @ParameterizedTest} annotation.
+     */
+    public static final String PARAMETERIZED_TEST_NAME_PATTERN = "{displayName} [{index}]; parameters: {argumentsWithNames}";
+
+    private JUnitTests() {
+        // prevent instantiation
+    }
+}

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -70,6 +70,7 @@ import org.eclipse.hono.client.kafka.producer.CachingKafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.KafkaProducerFactory;
 import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProperties;
 import org.eclipse.hono.service.management.device.Device;
+import org.eclipse.hono.test.JUnitTests;
 import org.eclipse.hono.test.VertxTools;
 import org.eclipse.hono.util.CommandConstants;
 import org.eclipse.hono.util.Constants;
@@ -492,7 +493,7 @@ public final class IntegrationTestSupport {
     /**
      * Pattern used for the <em>name</em> field of the {@code @ParameterizedTest} annotation.
      */
-    public static final String PARAMETERIZED_TEST_NAME_PATTERN = "{displayName} [{index}]; parameters: {argumentsWithNames}";
+    public static final String PARAMETERIZED_TEST_NAME_PATTERN = JUnitTests.PARAMETERIZED_TEST_NAME_PATTERN;
 
     /**
      * The default factor to apply when determining the timeout to use for executing test cases in a CI environment.
@@ -655,13 +656,13 @@ public final class IntegrationTestSupport {
      * @return The properties.
      */
     public static MessagingKafkaConsumerConfigProperties getKafkaConsumerConfig() {
-        LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
-        final MessagingKafkaConsumerConfigProperties consumerConfig = new MessagingKafkaConsumerConfigProperties();
-        consumerConfig.setConsumerConfig(Map.of(
+        LOGGER.info("Kafka Consumers are configured to connect to broker(s) at {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
+        final var configProps = new MessagingKafkaConsumerConfigProperties();
+        configProps.setConsumerConfig(Map.of(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS,
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
                 ConsumerConfig.GROUP_ID_CONFIG, "its-" + UUID.randomUUID()));
-        return consumerConfig;
+        return configProps;
     }
 
     /**
@@ -670,11 +671,11 @@ public final class IntegrationTestSupport {
      * @return The properties.
      */
     public static MessagingKafkaProducerConfigProperties getKafkaProducerConfig() {
-        LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
-        final MessagingKafkaProducerConfigProperties consumerConfig = new MessagingKafkaProducerConfigProperties();
-        consumerConfig.setProducerConfig(Map.of(
+        LOGGER.info("Kafka Producers are configured to connect to broker(s) at {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
+        final var configProps = new MessagingKafkaProducerConfigProperties();
+        configProps.setProducerConfig(Map.of(
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS));
-        return consumerConfig;
+        return configProps;
     }
 
     /**
@@ -683,7 +684,7 @@ public final class IntegrationTestSupport {
      * @return The properties.
      */
     public static KafkaAdminClientConfigProperties getKafkaAdminClientConfig() {
-        LOGGER.info("Configured to connect to Kafka on {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
+        LOGGER.info("Kafka Admin Clients are configured to connect to broker(s) at {}", IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS);
         final KafkaAdminClientConfigProperties adminClientConfig = new KafkaAdminClientConfigProperties();
         adminClientConfig.setAdminClientConfig(Map.of(
                 ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, IntegrationTestSupport.DOWNSTREAM_BOOTSTRAP_SERVERS,

--- a/tests/src/test/resources/logback-test-include-prod.xml
+++ b/tests/src/test/resources/logback-test-include-prod.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 
     See the NOTICE file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -21,11 +21,13 @@
   <logger name="org.eclipse.hono.client" level="INFO"/>
   <logger name="org.eclipse.hono.client.impl" level="INFO"/>
   <logger name="org.eclipse.hono.client.impl.HonoConnectionImpl" level="ERROR"/>
+  <logger name="org.eclipse.hono.client.kafka.consumer" level="INFO"/>
   <logger name="org.eclipse.hono.connection" level="INFO"/>
   <logger name="org.eclipse.hono.tests" level="INFO"/>
   <logger name="org.eclipse.hono.tests.CrudHttpClient" level="INFO"/>
   <logger name="org.eclipse.hono.tests.amqp" level="INFO"/>
   <logger name="org.eclipse.hono.tests.auth" level="INFO"/>
+  <logger name="org.eclipse.hono.tests.client" level="INFO"/>
   <logger name="org.eclipse.hono.tests.coap" level="INFO"/>
   <logger name="org.eclipse.hono.tests.http" level="INFO"/>
   <logger name="org.eclipse.hono.tests.jms" level="INFO"/>


### PR DESCRIPTION
This is the first step for #3558

The HonoKafkaConsumer has been adapted to explicitly enforce a rebalance in order to get assigned partitions for auto-created topics if the metadata.max.age.ms configuration property is not set or is set to a value greater than 500.

Kafka 3.5 seems to have changed its rebalancing behavior with regard to auto-created topics. Without this modification, the assignment of new partitions to the consumer will be deferred to after the metadata has become stale, which happens after 5 minutes if not explicitly overridden using the metadata.max.age.ms configuration property.