### PR TITLE
Use Mongo 6.0 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,20 +43,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        device-registry-name: [file,jdbc,mongodb-4.4,mongodb-5.0,mongodb-6.0]
+        device-registry-name: [file,jdbc,mongodb-4.4,mongodb-5.0,mongodb-6.0,mongodb-7.0]
         include:
         # Use Quarkus JVM images: file registry, AMQP messaging, Command Router with embedded cache
         - device-registry-name: file
           device-registry: file
           commandrouting-cache: embedded
           messaging-type: amqp
-          mongodb-image-name: mongo:4.4
+          mongodb-image-name: mongo:6.0
         # Use Quarkus JVM images: jdbc registry, Kafka messaging, Command Router with embedded cache
         - device-registry-name: jdbc
           device-registry: jdbc
           commandrouting-cache: embedded
           messaging-type: kafka
-          mongodb-image-name: mongo:4.4
+          mongodb-image-name: mongo:6.0
         # Use Quarkus JVM images: mongodb registry Kafka messaging, Command Router with data grid
         - device-registry-name: mongodb-4.4
           device-registry: mongodb
@@ -73,6 +73,11 @@ jobs:
           commandrouting-cache: server
           messaging-type: kafka
           mongodb-image-name: mongo:6.0
+        - device-registry-name: mongodb-7.0
+          device-registry: mongodb
+          commandrouting-cache: server
+          messaging-type: kafka
+          mongodb-image-name: mongo:7.0
 
     name: "Use ${{ matrix.device-registry-name }} registry, ${{ matrix.messaging-type }} messaging with ${{ matrix.commandrouting-cache }} cache"
     steps:

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,7 +42,7 @@
     <jjwt.version>0.11.5</jjwt.version>
     <kafka.image.name>docker.io/confluentinc/cp-kafka:7.3.5</kafka.image.name>
     <logback.version>1.4.11</logback.version>
-    <mongodb-image.name>docker.io/library/mongo:4.4</mongodb-image.name>
+    <mongodb-image.name>docker.io/library/mongo:6.0</mongodb-image.name>
     <native.image.name>quay.io/quarkus/quarkus-micro-image:2.0</native.image.name>
     <native.builder-image.name>mandrel</native.builder-image.name>
     <postgresql-image.name>docker.io/library/postgres:14-alpine</postgresql-image.name>

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -33,7 +33,7 @@ import io.vertx.ext.mongo.MongoClient;
 public final class MongoDbTestUtils {
 
     private static final MongoDBContainer MONGO_DB_CONTAINER;
-    private static final String MONGO_DB_IMAGE_NAME = System.getProperty("mongoDbImageName", "mongo:4.4");
+    private static final String MONGO_DB_IMAGE_NAME = System.getProperty("mongoDbImageName", "mongo:6.0");
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbTestUtils.class);
 
     static {

--- a/site/documentation/content/admin-guide/mongodb-device-registry-config.md
+++ b/site/documentation/content/admin-guide/mongodb-device-registry-config.md
@@ -21,9 +21,12 @@ The registry is compatible and known to work with following MongoDB versions:
 * [MongoDB 4.4](https://www.mongodb.com/docs/v4.4/release-notes/4.4/)
 * [MongoDB 5.0](https://www.mongodb.com/docs/v5.0/release-notes/5.0/)
 * [MongoDB 6.0](https://www.mongodb.com/docs/v6.0/release-notes/6.0/)
+* [MongoDB 7.0](https://www.mongodb.com/docs/v7.0/release-notes/7.0/)
 
-{{% notice info %}}
-The registry had originally been implemented as a Spring Boot application. That variant has been removed in Hono 2.0.0.
+{{% notice warning %}}
+According to the [Mongo DB Software Lifecycle Schedule](https://www.mongodb.com/support-policy/lifecycles) support
+for Mongo DB 4.4 will end Feb 2024. Consequently, support for Mongo 4.4 in Hono has been deprecated and will be removed
+in a future version altogether. Users are encouraged to migrate to Mongo DB 6.0 or later.
 {{% /notice %}}
 
 ## Service Configuration

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -12,6 +12,14 @@ description = "Information about changes in recent Hono releases. Includes new f
   being cleaned up. This has been fixed. Note that the solution requires the Hono protocol adapter pods to have
   a service account with an assigned RBAC role that allows to perform "get" on the "pods" resource.
 
+### Deprecations
+
+* According to the [MongoDB Software Lifecycle Schedule](https://www.mongodb.com/support-policy/lifecycles) support
+  for MongoDB 4.4 will end Feb 2024.
+  Until that date the MongoDB based Device Registry will be tested with MongoDB 4.4, 5.0, 6.0 and 7.0 in the CI workflows.
+  However, support for MongoDB 4.4 in Hono has been deprecated and will be removed in a future version altogether.
+  Users are encouraged to migrate to MongoDB 6.0 or later.
+
 ## 2.4.0
 
 ### New features


### PR DESCRIPTION
Unit and integration tests have been changed to use Mongo 6.0 by default. CI workflow has been adapted to test against Mongo versions 4.4, 5.0, 6.0 and 7.0.

Support for Mongo 4.4 has been deprecated.

Fixes #3540