### PR TITLE
Prevent duplicate workflow runs when pushing pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -19,8 +19,27 @@ name: Build and run integration tests
 on: [push,pull_request]
 
 jobs:
-  build:
 
+  pre_job:
+    # continue-on-error: true # Uncomment once integration is finished
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          cancel_others: 'true'
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+          paths_ignore: '["deploy/**", "legal/src/main/resources/legal/**", "site/**", "**/logo", "jenkins/**", "**/*.md"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
+
+  build:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Use the fkirc/skip-duplicate-actions GitHub action to prevent duplicate workflow runs.