### PR TITLE
Replace deprecated quarkus properties

### DIFF
--- a/adapter-base/src/test/resources/application.yml
+++ b/adapter-base/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/adapters/amqp/src/test/resources/application.yml
+++ b/adapters/amqp/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/adapters/coap/src/test/resources/application.yml
+++ b/adapters/coap/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/adapters/http-base/src/test/resources/application.yml
+++ b/adapters/http-base/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/adapters/lora/src/test/resources/application.yml
+++ b/adapters/lora/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/adapters/mqtt-base/src/test/resources/application.yml
+++ b/adapters/mqtt-base/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -187,6 +187,8 @@ otel.traces.sampler.arg=endpoint=http://${docker.host.address:localhost}:4317
 quarkus.devservices.enabled=false
 # app id
 quarkus.application.name=${app.id}
+# console color, also applies to console logging
+quarkus.console.color=true
 # Log setup
 quarkus.log.level=INFO
 quarkus.log.category."io.quarkus.vertx.core.runtime".level=DEBUG

--- a/cli/src/main/resources/application.yaml
+++ b/cli/src/main/resources/application.yaml
@@ -1,9 +1,9 @@
 quarkus:
   banner:
     enabled: false
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: ERROR
     min-level: TRACE
     category:

--- a/examples/protocol-gateway-example/src/main/resources/application.yml
+++ b/examples/protocol-gateway-example/src/main/resources/application.yml
@@ -10,9 +10,9 @@ gateway:
     serverRole: AMQP adapter
 
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/service-base/src/test/resources/application.yml
+++ b/service-base/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/services/auth-base/src/test/resources/application.yml
+++ b/services/auth-base/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/services/command-router/src/test/resources/application.yml
+++ b/services/command-router/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/services/device-registry-base/src/test/resources/application.yml
+++ b/services/device-registry-base/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/services/device-registry-jdbc/src/test/resources/application.yml
+++ b/services/device-registry-jdbc/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/services/device-registry-mongodb/src/main/resources/application.properties
+++ b/services/device-registry-mongodb/src/main/resources/application.properties
@@ -2,6 +2,3 @@ ${quarkus.application.properties}
 quarkus.jackson.accept-case-insensitive-enums=true
 # fail deserialization of JSON objects sent by clients if they contain unexpected content
 quarkus.jackson.fail-on-unknown-properties=true
-# this is needed in order to support mongodb+srv:// style connection strings in native executable
-# see https://quarkus.io/guides/mongodb
-quarkus.mongodb.native.dns.use-vertx-dns-resolver=true

--- a/services/device-registry-mongodb/src/test/resources/application.yml
+++ b/services/device-registry-mongodb/src/test/resources/application.yml
@@ -11,9 +11,9 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/amqp/application.yml
+++ b/tests/src/test/resources/amqp/application.yml
@@ -104,9 +104,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/auth/application.yml
+++ b/tests/src/test/resources/auth/application.yml
@@ -17,9 +17,9 @@ hono:
       supportedSaslMechanisms: "PLAIN"
 
 quarkus:
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/coap/application.yml
+++ b/tests/src/test/resources/coap/application.yml
@@ -103,9 +103,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/commandrouter/clustered-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/clustered-cache/application.yml
@@ -87,9 +87,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/commandrouter/embedded-cache/application.yml
+++ b/tests/src/test/resources/commandrouter/embedded-cache/application.yml
@@ -81,9 +81,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-h2/application.yml
@@ -71,9 +71,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
+++ b/tests/src/test/resources/deviceregistry-jdbc-postgres/application.yml
@@ -81,9 +81,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/deviceregistry-mongodb/application.yml
+++ b/tests/src/test/resources/deviceregistry-mongodb/application.yml
@@ -69,9 +69,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/http/application.yml
+++ b/tests/src/test/resources/http/application.yml
@@ -97,9 +97,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/lora/application.yml
+++ b/tests/src/test/resources/lora/application.yml
@@ -94,9 +94,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:

--- a/tests/src/test/resources/mqtt/application.yml
+++ b/tests/src/test/resources/mqtt/application.yml
@@ -95,9 +95,9 @@ quarkus:
     exporter:
       otlp:
         endpoint: "${otel-collector.endpoint}"
+  console:
+    color: true
   log:
-    console:
-      color: true
     level: INFO
     min-level: TRACE
     category:


### PR DESCRIPTION
Relates to #3547.
`quarkus.log.console.color` has been replaced by `quarkus.console.color`,
`quarkus.mongodb.native.dns.use-vertx-dns-resolver` is obsolete because usage of that resolver is now the default.