### PR TITLE
Use TLS endpoint when connecting to Sandbox

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
@@ -186,14 +186,23 @@ public class AmqpAdapter implements Callable<Integer> {
     }
 
     private void validateConnectionOptions() {
-        if (!connectionOptions.useSandbox && (connectionOptions.hostname.isEmpty() || connectionOptions.portNumber.isEmpty())) {
+        if (connectionOptions.useSandbox) {
+            if (!connectionOptions.trustStorePath.isPresent()) {
+                throw new ParameterException(
+                        spec.commandLine(),
+                        """
+                        Missing required option: '--ca-file=<path>' needs to be specified \
+                        when using '--sandbox'.
+                        """);
+            }
+        } else if (connectionOptions.hostname.isEmpty() || connectionOptions.portNumber.isEmpty()) {
             throw new ParameterException(
                     spec.commandLine(),
                     """
                     Missing required option: both '--host=<hostname>' and '--port=<portNumber> need to \
-                    be specified if not using '--sandbox'.
+                    be specified when not using '--sandbox'.
                     """);
-        }        
+        }
     }
 
     /**
@@ -207,12 +216,17 @@ public class AmqpAdapter implements Callable<Integer> {
             return Future.succeededFuture(client);
         }
 
+        validateConnectionOptions();
         final var clientConfig = new ClientConfigProperties();
         clientConfig.setReconnectAttempts(5);
         clientConfig.setServerRole("Hono AMQP Adapter");
+        connectionOptions.trustStorePath.ifPresent(path -> {
+            clientConfig.setTrustStorePath(path);
+            connectionOptions.trustStorePassword.ifPresent(clientConfig::setTrustStorePassword);
+        });
         if (connectionOptions.useSandbox) {
             clientConfig.setHost(ConnectionOptions.SANDBOX_HOST_NAME);
-            clientConfig.setPort(5672);
+            clientConfig.setPort(5671);
             Optional.ofNullable(connectionOptions.credentials).ifPresentOrElse(
                     creds -> {
                         clientConfig.setUsername(creds.username);
@@ -222,14 +236,10 @@ public class AmqpAdapter implements Callable<Integer> {
                         clientConfig.setUsername(SANDBOX_DEFAULT_DEVICE_AUTH_ID);
                         clientConfig.setPassword(SANDBOX_DEFAULT_DEVICE_PWD);
                     });
-            connectionOptions.trustStorePath.ifPresent(path -> {
-                clientConfig.setPort(5671);
-                clientConfig.setTrustStorePath(path);
-            });
         } else {
-            validateConnectionOptions();
             connectionOptions.hostname.ifPresent(clientConfig::setHost);
             connectionOptions.portNumber.ifPresent(clientConfig::setPort);
+            clientConfig.setHostnameVerificationRequired(!connectionOptions.disableHostnameVerification);
             if (clientCertInfo != null) {
                 clientConfig.setCertPath(clientCertInfo.certPath);
                 clientConfig.setKeyPath(clientCertInfo.keyPath);
@@ -237,9 +247,7 @@ public class AmqpAdapter implements Callable<Integer> {
                 clientConfig.setUsername(connectionOptions.credentials.username);
                 clientConfig.setPassword(connectionOptions.credentials.password);
             }
-            connectionOptions.trustStorePath.ifPresent(clientConfig::setTrustStorePath);
         }
-
         final var clientFactory = AmqpAdapterClient.create(HonoConnection.newConnection(vertx, clientConfig));
         return clientFactory.connect()
                 .onSuccess(con -> {

--- a/cli/src/main/java/org/eclipse/hono/cli/util/ConnectionOptions.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/util/ConnectionOptions.java
@@ -59,7 +59,8 @@ public class ConnectionOptions {
             names = { "--ca-file" },
             description = {
                 "Absolute path to a file containing trusted CA certificates to enable encrypted communication.",
-                "This option is required for connecting to endpoints using TLS."
+                "Needs to be set if connecting to an endpoint using TLS.",
+                "In particular, this needs to be set when connecting to the Hono Sandbox."
                 },
             order = 4)
     public Optional<String> trustStorePath;

--- a/examples/quickstart-python/README.md
+++ b/examples/quickstart-python/README.md
@@ -14,16 +14,16 @@ Then run the `quickstart.py` script.
 
 ## What does the script do?
 
-* Setup a Tenant and configure it to use AMQP 1.0 based messaging infrastructure
+* Setup a Tenant and configure it to use Kafka based messaging infrastructure
 * Setup a Device in the tenant
 * Add credentials to the device
-* Start a north bound AMQP 1.0 receiver for the messages sent by the tenant's devices
+* Start a north bound Kafka consumer for the messages sent by the tenant's devices
 * Send a Telemetry message via HTTP API
 * Send a Telemetry message via MQTT API 
 
 The output should roughly look like this
 
-```bash
+```
 Registered tenant f184ce49-d906-4a8c-af27-21df4c4acbf1
 Registered device 6f948c41-c2da-47f5-a52e-bf013f09e670
 Password is set!
@@ -31,16 +31,10 @@ You could now start the Hono Command Line Client in another terminal to consume 
 
 java -jar hono-cli-2.*-exec.jar app --sandbox consume --tenant=f184ce49-d906-4a8c-af27-21df4c4acbf1
 
-Using source: amqp://hono.eclipseprojects.io:15672/telemetry
-Using address: telemetry/f184ce49-d906-4a8c-af27-21df4c4acbf1
-Starting (north bound) AMQP Connection...
-Started
-Send Telemetry Message via HTTP
-HTTP sent successful
-Send Telemetry Message via MQTT
-Got a message:
-b'{"temp": 5, "transport": "http"}
-Got a message:
-b'{"temp": 17, "transport": "mqtt"}
-Stopping (north bound) AMQP Connection...
+created Kafka consumer ...
+waiting for Kafka messages
+Sending Telemetry message via HTTP adapter
+Sending Telemetry message via MQTT adapter
+Got a message: {"temp": 5, "transport": "http"}
+Got a message: {"temp": 17, "transport": "mqtt"}
 ```

--- a/examples/quickstart-python/requirements.txt
+++ b/examples/quickstart-python/requirements.txt
@@ -8,6 +8,6 @@
 #  http://www.eclipse.org/legal/epl-2.0
 #
 #  SPDX-License-Identifier: EPL-2.0
-paho-mqtt==1.5.0
+kafka-python==2.0.2
+paho-mqtt==1.6.1
 requests==2.31.0
-python-qpid-proton==0.31.0

--- a/site/documentation/content/getting-started/_index.md
+++ b/site/documentation/content/getting-started/_index.md
@@ -120,7 +120,7 @@ export REGISTRY_IP=hono.eclipseprojects.io
 export HTTP_ADAPTER_IP=hono.eclipseprojects.io
 export MQTT_ADAPTER_IP=hono.eclipseprojects.io
 export KAFKA_IP=hono.eclipseprojects.io
-export APP_OPTIONS="-H hono.eclipseprojects.io -P 9094 --ca-file /etc/ssl/certs/ca-certificates.crt -u hono -p hono-secret"
+export APP_OPTIONS="--sandbox --ca-file /etc/ssl/certs/ca-certificates.crt"
 export CURL_OPTIONS=
 export MOSQUITTO_OPTIONS='--cafile /etc/ssl/certs/ca-certificates.crt'
 EOS
@@ -136,7 +136,7 @@ export REGISTRY_IP=hono.eclipseprojects.io
 export HTTP_ADAPTER_IP=hono.eclipseprojects.io
 export MQTT_ADAPTER_IP=hono.eclipseprojects.io
 export KAFKA_IP=hono.eclipseprojects.io
-export APP_OPTIONS="-H hono.eclipseprojects.io -P 9094 --ca-file /etc/ssl/certs/ca-certificates.crt -u hono -p hono-secret"
+export APP_OPTIONS="--sandbox --ca-file /etc/ssl/certs/ca-certificates.crt"
 export CURL_OPTIONS=
 export MOSQUITTO_OPTIONS='--cafile /etc/ssl/certs/ca-certificates.crt'
 ~~~

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -148,13 +148,18 @@ adapter and prompts the user for a command to execute:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt
 ~~~
 ~~~
 hono-cli/amqp-device>
 ~~~
 
 A list of available commands can be displayed using the `help` command, `exit` will close the client.
+
+{% notice info %}
+The example command above uses the default path to a Linux based system's trusted CA certificates.
+The path may need to be adapted when running on a different type of operating system.
+{{% /notice %}}
 
 ## Publishing Telemetry Data
 
@@ -208,7 +213,7 @@ Start the client in interactive mode:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp -H hono.eclipseprojects.io -P 5672 -u sensor1@DEFAULT_TENANT -p hono-secret
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt
 ~~~
 ~~~
 hono-cli/amqp-device>
@@ -231,7 +236,7 @@ The message can also be sent in non-interactive mode:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox telemetry --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt telemetry --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 Note that sending the message this way will take a little longer than in interactive mode because the connection to the
@@ -277,7 +282,7 @@ publishing some JSON data on behalf of device `4711` of tenant `DEFAULT_TENANT` 
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox telemetry --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt telemetry --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -329,7 +334,7 @@ some JSON data on behalf of device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox -u gw@DEFAULT_TENANT -p gw-secret telemetry --device 4712 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt -u gw@DEFAULT_TENANT -p gw-secret telemetry --device 4712 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -381,7 +386,7 @@ Publish a JSON string for the authenticated device (`4711`):
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox event --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt event --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 ## Publish an Event (unauthenticated Device)
@@ -422,7 +427,7 @@ publishing some JSON data on behalf of device `4711` of tenant `DEFAULT_TENANT` 
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox event --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt event --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -467,7 +472,7 @@ some JSON data on behalf of device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox -u gw@DEFAULT_TENANT -p gw-secret event --device 4712 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt -u gw@DEFAULT_TENANT -p gw-secret event --device 4712 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -599,7 +604,7 @@ Start the client in interactive mode:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp -H hono.eclipseprojects.io -P 5672 -u sensor1@DEFAULT_TENANT -p hono-secret
+java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt 
 hono-cli/amqp-device>
 ~~~
 
@@ -646,7 +651,7 @@ command to send a request-response command to device `4711`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar app --sandbox --amqp command req -d 4711 -n setColor --payload '{"r": 128,"g": 100,"b": 50}'
+java -jar hono-cli-*-exec.jar app --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt command req -d 4711 -n setColor --payload '{"r": 128,"g": 100,"b": 50}'
 ~~~
 
 This will result in the device's response being printed to the console:
@@ -659,7 +664,7 @@ It is also possible to send a one-way command:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar app --sandbox --amqp command ow -d 4711 -n setVolume --payload '{"level": 50}'
+java -jar hono-cli-*-exec.jar app --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt command ow -d 4711 -n setVolume --payload '{"level": 50}'
 ~~~
 
 ## Downstream Meta Data

--- a/site/homepage/content/release-notes.md
+++ b/site/homepage/content/release-notes.md
@@ -16,6 +16,8 @@ description = "Information about changes in recent Hono releases. Includes new f
   This has been fixed.
 * The integration tests now use Apache Kafka 3.5.0 in Raft mode which no longer requires running a separate Apache Zookeeper
   instance and thus simplifies test setup and configuration.
+* The command line client was still trying to connect to the insecure ports of the Sandbox. This has been changed so that
+  the client now uses the TLS endpoints and requires the user to specify a trust store for validating the server certificate.
 
 ### Deprecations
 


### PR DESCRIPTION
Addresses #3569

The command line client was still trying to connect to the insecure ports of the Sandbox.

This has been changed so that the client now uses the TLS endpoints and requires the user to specify a trust store for validating the server certificate.

The Getting Started guide has been adapted accordingly.