### PR TITLE
[#3566] Replace direct Vert.x CompositeFuture method calls with Future method calls

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterApplication.java
@@ -96,7 +96,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
 import io.smallrye.config.ConfigMapping;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
@@ -317,7 +316,7 @@ public abstract class AbstractProtocolAdapterApplication<C extends ProtocolAdapt
             })
             .onFailure(t -> LOG.error("failed to deploy notification receiver verticle(s)", t));
 
-        CompositeFuture.all(adapterTracker, notificationReceiverTracker)
+        Future.all(adapterTracker, notificationReceiverTracker)
             .map(deploymentResult)
             .onComplete(deploymentCheck);
     }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/AbstractProtocolAdapterBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,6 @@ import org.eclipse.hono.util.TenantObject;
 import io.micrometer.core.instrument.Timer.Sample;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.opentracing.SpanContext;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -367,15 +366,14 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
 
     private Future<Void> closeServiceClients() {
 
-        @SuppressWarnings("rawtypes")
-        final List<Future> results = new ArrayList<>();
+        final List<Future<Void>> results = new ArrayList<>();
         results.add(tenantClient.stop());
         results.add(registrationClient.stop());
         results.add(credentialsClient.stop());
         results.add(commandConsumerFactory.stop());
         results.add(commandRouterClient.stop());
         results.add(messagingClientProviders.stop());
-        return CompositeFuture.all(results).mapEmpty();
+        return Future.all(results).mapEmpty();
     }
 
     /**
@@ -459,7 +457,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                     }
                 });
 
-        return CompositeFuture.all(
+        return Future.all(
                 connectionLimitCheckResult,
                 checkConnectionDurationLimit(tenantConfig, spanContext),
                 messageLimitCheckResult).mapEmpty();
@@ -923,7 +921,7 @@ public abstract class AbstractProtocolAdapterBase<T extends ProtocolAdapterPrope
                 context);
         final Future<TenantObject> tenantConfigTracker = getTenantConfiguration(tenant, context);
 
-        return CompositeFuture.all(tokenTracker, tenantConfigTracker).compose(ok -> {
+        return Future.all(tokenTracker, tenantConfigTracker).compose(ok -> {
             if (tenantConfigTracker.result().isAdapterEnabled(getTypeName())) {
                 final Map<String, Object> props = new HashMap<>();
                 props.put(MessageHelper.APP_PROPERTY_ORIG_ADAPTER, getTypeName());

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/MessagingClientProviders.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/MessagingClientProviders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,7 +26,6 @@ import org.eclipse.hono.util.TenantObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 
@@ -141,7 +140,7 @@ public final class MessagingClientProviders implements Lifecycle {
     @Override
     public Future<Void> start() {
 
-        return CompositeFuture.all(
+        return Future.all(
                 telemetrySenderProvider.start(),
                 eventSenderProvider.start(),
                 commandResponseSenderProvider.start()).mapEmpty();
@@ -149,7 +148,7 @@ public final class MessagingClientProviders implements Lifecycle {
 
     @Override
     public Future<Void> stop() {
-        return CompositeFuture.all(
+        return Future.all(
                 telemetrySenderProvider.stop(),
                 eventSenderProvider.stop(),
                 commandResponseSenderProvider.stop()).mapEmpty();

--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/AbstractVertxBasedCoapAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,7 +25,6 @@ import org.eclipse.hono.adapter.AbstractProtocolAdapterBase;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.Futures;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -211,7 +210,7 @@ public abstract class AbstractVertxBasedCoapAdapter<T extends CoapAdapterPropert
                                 this.insecureEndpoint = ep;
                             });
 
-                    return CompositeFuture.any(insecureEndpointFuture, secureEndpointFuture)
+                    return Future.any(insecureEndpointFuture, secureEndpointFuture)
                             .map(ok -> {
                                 this.server = newServer;
                                 return newServer;

--- a/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/CommandResponseResource.java
+++ b/adapters/coap/src/main/java/org/eclipse/hono/adapter/coap/CommandResponseResource.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -170,8 +169,8 @@ public class CommandResponseResource extends AbstractHonoResource {
                         String.format("command-request-id [%s] or status code [%s] is missing/invalid",
                                 commandRequestId, responseStatus))));
 
-        return CompositeFuture.all(tenantTracker, commandResponseTracker, deviceRegistrationTracker)
-                .compose(ok -> CompositeFuture.all(
+        return Future.all(tenantTracker, commandResponseTracker, deviceRegistrationTracker)
+                .compose(ok -> Future.all(
                             getAdapter().isAdapterEnabled(tenantTracker.result()),
                             getAdapter().checkMessageLimit(tenantTracker.result(), payload.length(), currentSpan.context()))
                             .mapEmpty())

--- a/cli/src/main/java/org/eclipse/hono/cli/app/TelemetryAndEvent.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/TelemetryAndEvent.java
@@ -24,13 +24,13 @@ import java.util.concurrent.CompletionException;
 
 import org.eclipse.hono.application.client.ApplicationClient;
 import org.eclipse.hono.application.client.DownstreamMessage;
+import org.eclipse.hono.application.client.MessageConsumer;
 import org.eclipse.hono.application.client.MessageContext;
 import org.eclipse.hono.cli.util.CommandUtils;
 import org.eclipse.hono.cli.util.PropertiesVersionProvider;
 import org.eclipse.hono.util.Constants;
 
 import io.quarkus.runtime.Quarkus;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -103,8 +103,7 @@ public class TelemetryAndEvent implements Callable<Integer> {
             });
         };
 
-        @SuppressWarnings("rawtypes")
-        final List<Future> consumerFutures = new ArrayList<>();
+        final List<Future<MessageConsumer>> consumerFutures = new ArrayList<>();
         if (supportedMessageTypes.contains(MESSAGE_TYPE_EVENT)) {
             consumerFutures.add(
                     client.createEventConsumer(
@@ -121,7 +120,7 @@ public class TelemetryAndEvent implements Callable<Integer> {
                             closeHandler));
         }
 
-        return CompositeFuture.all(consumerFutures)
+        return Future.all(consumerFutures)
                 .mapEmpty();
     }
 

--- a/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
+++ b/client-device-connection-infinispan/src/main/java/org/eclipse/hono/deviceconnection/infinispan/client/CacheBasedDeviceConnectionInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
@@ -565,8 +564,7 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
     private Future<Map<String, String>> checkAdapterInstanceIds(final String tenantId,
             final Map<String, String> deviceToInstanceIdMap, final Span span) {
 
-        @SuppressWarnings("rawtypes")
-        final List<Future> mappingFutures = new ArrayList<>();
+        final List<Future<String>> mappingFutures = new ArrayList<>();
         final Map<String, String> deviceToInstanceIdMapResult = new HashMap<>();
         deviceToInstanceIdMap.entrySet().forEach(entry -> {
             final Future<String> mappingFuture = checkAdapterInstanceId(entry.getValue(), tenantId, entry.getKey(), span)
@@ -579,7 +577,7 @@ public final class CacheBasedDeviceConnectionInfo implements DeviceConnectionInf
             mappingFutures.add(mappingFuture);
         });
 
-        return CompositeFuture.join(mappingFutures).map(deviceToInstanceIdMapResult);
+        return Future.join(mappingFutures).map(deviceToInstanceIdMapResult);
     }
 
     private Future<String> checkAdapterInstanceId(

--- a/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
+++ b/clients/application-kafka/src/main/java/org/eclipse/hono/application/client/kafka/impl/KafkaApplicationClientImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,7 +36,6 @@ import org.eclipse.hono.client.kafka.producer.MessagingKafkaProducerConfigProper
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -108,16 +107,15 @@ public class KafkaApplicationClientImpl extends KafkaBasedCommandSender implemen
         addOnKafkaProducerReadyHandler(handler);
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
     public Future<Void> stop() {
         // stop created consumers
-        final List<Future> closeKafkaClientsTracker = consumersToCloseOnStop.stream()
+        final List<Future<Void>> closeKafkaClientsTracker = consumersToCloseOnStop.stream()
                 .map(MessageConsumer::close)
                 .collect(Collectors.toList());
         // add command sender related clients
         closeKafkaClientsTracker.add(super.stop());
-        return CompositeFuture.join(closeKafkaClientsTracker)
+        return Future.join(closeKafkaClientsTracker)
                 .mapEmpty();
     }
 

--- a/clients/client-common/src/main/java/org/eclipse/hono/client/util/MessagingClientProvider.java
+++ b/clients/client-common/src/main/java/org/eclipse/hono/client/util/MessagingClientProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,7 +28,6 @@ import org.eclipse.hono.util.MessagingType;
 import org.eclipse.hono.util.TenantConstants;
 import org.eclipse.hono.util.TenantObject;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -175,12 +174,11 @@ public final class MessagingClientProvider<T extends MessagingClient & Lifecycle
         }
         requireClientsConfigured();
 
-        @SuppressWarnings("rawtypes")
-        final List<Future> futures = clientImplementations.values()
+        final List<Future<Void>> futures = clientImplementations.values()
                 .stream()
                 .map(Lifecycle::start)
                 .collect(Collectors.toList());
-        return CompositeFuture.all(futures).mapEmpty();
+        return Future.all(futures).mapEmpty();
     }
 
     @Override
@@ -188,11 +186,10 @@ public final class MessagingClientProvider<T extends MessagingClient & Lifecycle
         if (!stopCalled.compareAndSet(false, true)) {
             return Future.succeededFuture();
         }
-        @SuppressWarnings("rawtypes")
-        final List<Future> futures = clientImplementations.values()
+        final List<Future<Void>> futures = clientImplementations.values()
                 .stream()
                 .map(Lifecycle::stop)
                 .collect(Collectors.toList());
-        return CompositeFuture.all(futures).mapEmpty();
+        return Future.all(futures).mapEmpty();
     }
 }

--- a/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
+++ b/clients/command-amqp/src/main/java/org/eclipse/hono/client/command/amqp/ProtonBasedCommandRouterClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.tag.Tags;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.DecodeException;
@@ -247,12 +246,11 @@ public class ProtonBasedCommandRouterClient extends AbstractRequestResponseServi
                 }
             }
         }
-        @SuppressWarnings("rawtypes")
-        final List<Future> resultFutures = new ArrayList<>();
+        final List<Future<Void>> resultFutures = new ArrayList<>();
         deviceToGatewayMapPerTenant.forEach((tenantId, deviceToGatewayMap) -> {
             resultFutures.add(setLastKnownGateways(tenantId, deviceToGatewayMap, currentSpan.context()));
         });
-        CompositeFuture.join(resultFutures)
+        Future.join(resultFutures)
                 .onComplete(ar -> {
                     if (ar.failed()) {
                         TracingHelper.logError(currentSpan, ar.cause());

--- a/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
+++ b/clients/command-kafka/src/main/java/org/eclipse/hono/client/command/kafka/KafkaBasedInternalCommandConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -380,7 +379,7 @@ public class KafkaBasedInternalCommandConsumer implements InternalCommandConsume
             Optional.ofNullable(retryCreateTopicTimerId)
                     .ifPresent(vertx::cancelTimer);
 
-            return CompositeFuture.all(closeAdminClient(), stopConsumer())
+            return Future.all(closeAdminClient(), stopConsumer())
                 .mapEmpty();
         });
     }

--- a/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumer.java
+++ b/clients/command-pubsub/src/main/java/org/eclipse/hono/client/command/pubsub/PubSubBasedInternalCommandConsumer.java
@@ -41,7 +41,6 @@ import com.google.pubsub.v1.PubsubMessage;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -261,7 +260,7 @@ public class PubSubBasedInternalCommandConsumer implements InternalCommandConsum
 
     @Override
     public Future<Void> stop() {
-        return lifecycleStatus.runStopAttempt(() -> CompositeFuture.all(
+        return lifecycleStatus.runStopAttempt(() -> Future.all(
                 subscriberFactory.closeSubscriber(CommandConstants.INTERNAL_COMMAND_ENDPOINT, adapterInstanceId),
                 vertx.executeBlocking(promise -> {
                     adminClientManager.closeAdminClients();

--- a/clients/command/src/main/java/org/eclipse/hono/client/command/ProtocolAdapterCommandConsumerFactoryImpl.java
+++ b/clients/command/src/main/java/org/eclipse/hono/client/command/ProtocolAdapterCommandConsumerFactoryImpl.java
@@ -36,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.SpanContext;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -166,14 +165,13 @@ public class ProtocolAdapterCommandConsumerFactoryImpl implements ProtocolAdapte
                             });
                     internalCommandConsumerSuppliers.clear();
                     readinessHandler = null;
-                    @SuppressWarnings("rawtypes")
-                    final List<Future> futures = internalCommandConsumers.stream()
+                    final List<Future<Void>> futures = internalCommandConsumers.stream()
                             .map(Lifecycle::start)
                             .collect(Collectors.toList());
                     if (futures.isEmpty()) {
                         return Future.failedFuture("no command consumer registered");
                     }
-                    return CompositeFuture.all(futures).mapEmpty();
+                    return Future.all(futures).mapEmpty();
                 })
                 .recover(thr -> {
                     startFailureMessage = thr.getMessage();
@@ -200,11 +198,10 @@ public class ProtocolAdapterCommandConsumerFactoryImpl implements ProtocolAdapte
         if (!stopCalled.compareAndSet(false, true)) {
             return Future.succeededFuture();
         }
-        @SuppressWarnings("rawtypes")
-        final List<Future> futures = internalCommandConsumers.stream()
+        final List<Future<Void>> futures = internalCommandConsumers.stream()
                 .map(Lifecycle::stop)
                 .collect(Collectors.toList());
-        return CompositeFuture.all(futures).mapEmpty();
+        return Future.all(futures).mapEmpty();
     }
 
     @Override

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -905,7 +904,7 @@ public class HonoKafkaConsumer<V> implements Lifecycle, ServiceClient {
         }
         // init kafkaConsumerWorker; it has to be retrieved after the first "subscribe" invocation
         kafkaConsumerWorker = getKafkaConsumerWorker(kafkaConsumer);
-        return CompositeFuture.all(subscribeDonePromise.future(), partitionAssignmentDone.future()).mapEmpty();
+        return Future.all(subscribeDonePromise.future(), partitionAssignmentDone.future()).mapEmpty();
     }
 
     /**

--- a/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationReceiver.java
+++ b/clients/notification-amqp/src/main/java/org/eclipse/hono/client/notification/amqp/ProtonBasedNotificationReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,7 +30,6 @@ import org.eclipse.hono.notification.AbstractNotification;
 import org.eclipse.hono.notification.NotificationReceiver;
 import org.eclipse.hono.notification.NotificationType;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
@@ -121,10 +120,9 @@ public class ProtonBasedNotificationReceiver extends AbstractServiceClient imple
             log.debug("recreate notification consumer links");
             connection.isConnected(getDefaultConnectionCheckTimeout())
                     .compose(res -> {
-                        @SuppressWarnings("rawtypes")
-                        final List<Future> consumerCreationFutures = new ArrayList<>();
+                        final List<Future<ProtonReceiver>> consumerCreationFutures = new ArrayList<>();
                         addresses.forEach(address -> consumerCreationFutures.add(createNotificationConsumerIfNeeded(address)));
-                        return CompositeFuture.join(consumerCreationFutures);
+                        return Future.join(consumerCreationFutures);
                     }).onComplete(ar -> {
                         recreatingConsumers.set(false);
                         if (tryAgainRecreatingConsumers.compareAndSet(true, false) || ar.failed()) {

--- a/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
+++ b/service-base/src/main/java/org/eclipse/hono/service/amqp/AmqpServiceBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,7 +38,6 @@ import org.eclipse.hono.util.ResourceIdentifier;
 import org.eclipse.hono.util.Strings;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -235,28 +234,26 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
 
     private Future<Void> startEndpoints() {
 
-        @SuppressWarnings("rawtypes")
         final
-        List<Future> endpointFutures = new ArrayList<>(endpoints.size());
+        List<Future<Void>> endpointFutures = new ArrayList<>(endpoints.size());
         for (final AmqpEndpoint ep : endpoints.values()) {
             log.info("starting endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
             endpointFutures.add(ep.start());
         }
-        return CompositeFuture.all(endpointFutures)
+        return Future.all(endpointFutures)
                 .map(ok -> (Void) null)
                 .recover(Future::failedFuture);
     }
 
     private Future<Void> stopEndpoints() {
 
-        @SuppressWarnings("rawtypes")
         final
-        List<Future> endpointFutures = new ArrayList<>(endpoints.size());
+        List<Future<Void>> endpointFutures = new ArrayList<>(endpoints.size());
         for (final AmqpEndpoint ep : endpoints.values()) {
             log.info("stopping endpoint [name: {}, class: {}]", ep.getName(), ep.getClass().getName());
             endpointFutures.add(ep.stop());
         }
-        return CompositeFuture.all(endpointFutures)
+        return Future.all(endpointFutures)
                 .map(ok -> (Void) null)
                 .recover(Future::failedFuture);
     }
@@ -368,7 +365,7 @@ public abstract class AmqpServiceBase<T extends ServiceConfigProperties> extends
     public final Future<Void> stopInternal() {
 
         return preShutdown()
-                .compose(s -> CompositeFuture.all(stopServer(), stopInsecureServer()))
+                .compose(s -> Future.all(stopServer(), stopInsecureServer()))
                 .compose(s -> stopEndpoints())
                 .compose(s -> postShutdown());
     }

--- a/services/auth/src/main/java/org/eclipse/hono/authentication/app/Application.java
+++ b/services/auth/src/main/java/org/eclipse/hono/authentication/app/Application.java
@@ -32,7 +32,6 @@ import org.eclipse.hono.service.auth.JjwtBasedAuthTokenValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.proton.sasl.ProtonSaslAuthenticatorFactory;
@@ -84,7 +83,7 @@ public class Application extends AbstractServiceApplication {
             });
 
 
-        CompositeFuture.all(authServiceDeploymentTracker, amqpServerDeploymentTracker)
+        Future.all(authServiceDeploymentTracker, amqpServerDeploymentTracker)
             .map(deploymentResult)
             .onComplete(deploymentCheck);
     }

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableManagementStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/device/TableManagementStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -52,7 +52,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.log.Fields;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
@@ -362,7 +361,7 @@ public class TableManagementStore extends AbstractDeviceStore {
             final Set<String> memberOf,
             final SpanContext context) {
 
-        return CompositeFuture.all(memberOf.stream()
+        return Future.all(memberOf.stream()
                         .map(groupId -> {
 
                             final var expanded = this.createMemberOfStatement.expand(params -> {
@@ -774,7 +773,7 @@ public class TableManagementStore extends AbstractDeviceStore {
                                         // then create new entries
                                         .compose(updatedCredentials -> {
                                             updatedCredentials.createMissingSecretIds();
-                                            return CompositeFuture.all(updatedCredentials.getData().stream()
+                                            return Future.all(updatedCredentials.getData().stream()
                                                             .map(JsonObject::mapFrom)
                                                             .filter(c -> c.containsKey("type") && c.containsKey("auth-id"))
                                                             .map(c -> this.insertCredentialEntryStatement

--- a/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/tenant/ManagementStore.java
+++ b/services/base-jdbc/src/main/java/org/eclipse/hono/service/base/jdbc/store/tenant/ManagementStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.Json;
@@ -255,7 +254,7 @@ public class ManagementStore extends AbstractTenantStore {
             return Future.succeededFuture();
         }
 
-        return CompositeFuture
+        return Future
 
                 .all(tenant.getTrustedCertificateAuthorities().stream()
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/Application.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/app/Application.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -80,7 +80,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.health.api.HealthRegistry;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
@@ -306,7 +305,7 @@ public class Application extends NotificationSupportingServiceApplication {
                         }))
                 .orElse(Future.succeededFuture());
 
-        CompositeFuture.all(
+        Future.all(
                 authServiceDeploymentTracker,
                 amqpServerDeploymentTracker,
                 notificationReceiverTracker,

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,7 +50,6 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -236,13 +235,13 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
         kafkaConsumer.setOnPartitionsLostHandler(
                 partitions -> commandQueue.setRevokedPartitions(Helper.to(partitions)));
 
-        CompositeFuture.all(
+        Future.all(
                 internalCommandSenderTracker.future(),
                 commandResponseSenderTracker.future(),
                 consumerTracker.future())
             .onSuccess(ok -> lifecycleStatus.setStarted());
 
-        return CompositeFuture.all(commandHandler.start(), kafkaConsumer.start()).mapEmpty();
+        return Future.all(commandHandler.start(), kafkaConsumer.start()).mapEmpty();
     }
 
     private void registerTenantCreationListener() {
@@ -270,7 +269,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
     @Override
     public Future<Void> stop() {
 
-        return lifecycleStatus.runStopAttempt(() -> CompositeFuture.join(kafkaConsumer.stop(), commandHandler.stop())
+        return lifecycleStatus.runStopAttempt(() -> Future.join(kafkaConsumer.stop(), commandHandler.stop())
                 .mapEmpty());
     }
 

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,7 +30,6 @@ import io.micrometer.core.instrument.Timer;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -82,7 +81,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
      */
     @Override
     public Future<Void> start() {
-        return CompositeFuture.all(super.start(), kafkaBasedCommandResponseSender.start()).mapEmpty();
+        return Future.all(super.start(), kafkaBasedCommandResponseSender.start()).mapEmpty();
     }
 
     /**
@@ -93,7 +92,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandler extends AbstractMappin
      */
     @Override
     public Future<Void> stop() {
-        return CompositeFuture.join(super.stop(), kafkaBasedCommandResponseSender.stop()).mapEmpty();
+        return Future.join(super.stop(), kafkaBasedCommandResponseSender.stop()).mapEmpty();
     }
 
     /**

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedCommandConsumerFactoryImpl.java
@@ -47,7 +47,6 @@ import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
@@ -140,7 +139,7 @@ public class PubSubBasedCommandConsumerFactoryImpl implements CommandConsumerFac
     @Override
     public Future<Void> stop() {
         return lifecycleStatus.runStopAttempt(
-                () -> CompositeFuture.join(subscriberFactory.closeAllSubscribers(), commandHandler.stop()).mapEmpty());
+                () -> Future.join(subscriberFactory.closeAllSubscribers(), commandHandler.stop()).mapEmpty());
     }
 
     @Override

--- a/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedMappingAndDelegatingCommandHandler.java
+++ b/services/command-router/src/main/java/org/eclipse/hono/commandrouter/impl/pubsub/PubSubBasedMappingAndDelegatingCommandHandler.java
@@ -33,7 +33,6 @@ import io.micrometer.core.instrument.Timer;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 
@@ -83,7 +82,7 @@ public class PubSubBasedMappingAndDelegatingCommandHandler
      */
     @Override
     public Future<Void> start() {
-        return CompositeFuture.all(super.start(), pubSubBasedCommandResponseSender.start()).mapEmpty();
+        return Future.all(super.start(), pubSubBasedCommandResponseSender.start()).mapEmpty();
     }
 
     /**
@@ -94,7 +93,7 @@ public class PubSubBasedMappingAndDelegatingCommandHandler
      */
     @Override
     public Future<Void> stop() {
-        return CompositeFuture.join(super.stop(), pubSubBasedCommandResponseSender.stop()).mapEmpty();
+        return Future.join(super.stop(), pubSubBasedCommandResponseSender.stop()).mapEmpty();
     }
 
     /**

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/amqp/ProtonBasedMappingAndDelegatingCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,6 @@ import org.mockito.ArgumentCaptor;
 import io.micrometer.core.instrument.Timer;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopTracerFactory;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -406,7 +405,7 @@ public class ProtonBasedMappingAndDelegatingCommandHandlerTest {
                 .mapAndDelegateIncomingCommandMessage(tenantId, mock(ProtonDelivery.class), message4);
 
         // THEN the messages are delegated in the original order
-        CompositeFuture.all(cmd1Future, cmd2Future, cmd3Future, cmd4Future)
+        Future.all(cmd1Future, cmd2Future, cmd3Future, cmd4Future)
                 .onComplete(ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         final ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
@@ -478,7 +477,7 @@ public class ProtonBasedMappingAndDelegatingCommandHandlerTest {
                 .mapAndDelegateIncomingCommandMessage(tenantId, mock(ProtonDelivery.class), message4);
 
         // THEN the messages are delegated in the original order, with command 1 left out because it timed out
-        CompositeFuture.all(cmd2Future, cmd3Future, cmd4Future)
+        Future.all(cmd2Future, cmd3Future, cmd4Future)
                 .onComplete(ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         assertThat(cmd1Future.failed()).isTrue();

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedMappingAndDelegatingCommandHandlerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -55,7 +55,6 @@ import org.mockito.ArgumentCaptor;
 
 import io.micrometer.core.instrument.Timer;
 import io.opentracing.Tracer;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -298,7 +297,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
         final Future<Void> cmd4Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord4);
 
         // THEN the messages are delegated in the original order
-        CompositeFuture.all(cmd1Future, cmd2Future, cmd3Future, cmd4Future)
+        Future.all(cmd1Future, cmd2Future, cmd3Future, cmd4Future)
                 .onComplete(ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         final ArgumentCaptor<CommandContext> commandContextCaptor = ArgumentCaptor.forClass(CommandContext.class);
@@ -357,7 +356,7 @@ public class KafkaBasedMappingAndDelegatingCommandHandlerTest {
         final Future<Void> cmd4Future = cmdHandler.mapAndDelegateIncomingCommandMessage(commandRecord4);
 
         // THEN the messages are delegated in the original order, with command 1 left out because it timed out
-        CompositeFuture.all(cmd2Future, cmd3Future, cmd4Future)
+        Future.all(cmd2Future, cmd3Future, cmd4Future)
                 .onComplete(ctx.succeeding(r -> {
                     ctx.verify(() -> {
                         assertThat(cmd1Future.failed()).isTrue();

--- a/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueueTest.java
+++ b/services/command-router/src/test/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaCommandProcessingQueueTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.opentracing.Span;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -65,7 +64,6 @@ public class KafkaCommandProcessingQueueTest {
      * @param ctx The vert.x test context.
      */
     @Test
-    @SuppressWarnings("rawtypes")
     void testSendActionIsInvokedInOrder(final Vertx vertx, final VertxTestContext ctx) {
         final Context vertxContext = vertx.getOrCreateContext();
         vertxContext.runOnContext(v -> {
@@ -80,7 +78,7 @@ public class KafkaCommandProcessingQueueTest {
             // WHEN applying the sendAction on these commands in the reverse order
             final LinkedList<KafkaBasedCommandContext> sendActionInvoked = new LinkedList<>();
             final LinkedList<KafkaBasedCommandContext> applySendActionSucceeded = new LinkedList<>();
-            final List<Future> resultFutures = new LinkedList<>();
+            final List<Future<Void>> resultFutures = new LinkedList<>();
             commandContexts.descendingIterator().forEachRemaining(context -> {
                 resultFutures.add(kafkaCommandProcessingQueue
                         .applySendCommandAction(context, () -> {
@@ -90,7 +88,7 @@ public class KafkaCommandProcessingQueueTest {
                         .onSuccess(v2 -> applySendActionSucceeded.add(context)));
             });
 
-            CompositeFuture.all(resultFutures).onComplete(ctx.succeeding(ar -> {
+            Future.all(resultFutures).onComplete(ctx.succeeding(ar -> {
                 ctx.verify(() -> {
                     // THEN the commands got sent in the original order
                     assertThat(sendActionInvoked).isEqualTo(commandContexts);

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractDeviceRegistryApplication.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/app/AbstractDeviceRegistryApplication.java
@@ -23,7 +23,6 @@ import org.eclipse.hono.util.WrappedLifecycleComponentVerticle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Verticle;
@@ -97,7 +96,7 @@ public abstract class AbstractDeviceRegistryApplication extends AbstractServiceA
             })
             .onFailure(t -> log.error("failed to deploy HTTP server verticle(s)", t));
 
-        CompositeFuture.all(
+        Future.all(
                 authServiceDeploymentTracker,
                 notificationSenderDeploymentTracker,
                 amqpServerDeploymentTracker,

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractRegistrationService.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/deviceregistry/service/device/AbstractRegistrationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -265,7 +264,7 @@ public abstract class AbstractRegistrationService implements RegistrationService
                     final Future<RegistrationResult> deviceInfoTracker = getRegistrationInformation(DeviceKey.from(tenantId, deviceId), span);
                     final Future<RegistrationResult> gatewayInfoTracker = getRegistrationInformation(DeviceKey.from(tenantId, gatewayId), span);
 
-                    return CompositeFuture
+                    return Future
                             .all(deviceInfoTracker, gatewayInfoTracker)
                             .compose(ok -> {
 

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/DelegatingCredentialsManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/credentials/DelegatingCredentialsManagementHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,6 @@ import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import io.opentracing.Span;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -112,7 +111,7 @@ public class DelegatingCredentialsManagementHttpEndpoint<S extends CredentialsMa
         final Future<String> tenantId = getRequestParameter(ctx, PARAM_TENANT_ID, getPredicate(config.getTenantIdPattern(), false));
         final Future<String> deviceId = getRequestParameter(ctx, PARAM_DEVICE_ID, getPredicate(config.getDeviceIdPattern(), false));
 
-        CompositeFuture.all(tenantId, deviceId)
+        Future.all(tenantId, deviceId)
             .compose(ok -> {
                 TracingHelper.setDeviceTags(span, tenantId.result(), deviceId.result());
                 logger.debug("getting credentials [tenant: {}, device-id: {}]]",
@@ -154,7 +153,7 @@ public class DelegatingCredentialsManagementHttpEndpoint<S extends CredentialsMa
         final Future<String> deviceId = getRequestParameter(ctx, PARAM_DEVICE_ID, getPredicate(config.getDeviceIdPattern(), false));
         final Future<List<CommonCredential>> updatedCredentials = fromPayload(ctx);
 
-        CompositeFuture.all(tenantId, deviceId, updatedCredentials)
+        Future.all(tenantId, deviceId, updatedCredentials)
             .compose(ok -> {
                 TracingHelper.setDeviceTags(span, tenantId.result(), deviceId.result());
                 logger.debug("updating {} credentials [tenant: {}, device-id: {}]",

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/device/DelegatingDeviceManagementHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -30,7 +30,6 @@ import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import io.opentracing.Span;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -151,7 +150,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         final Future<String> tenantId = getRequestParameter(ctx, PARAM_TENANT_ID, getPredicate(config.getTenantIdPattern(), false));
         final Future<String> deviceId = getRequestParameter(ctx, PARAM_DEVICE_ID, getPredicate(config.getDeviceIdPattern(), false));
 
-        CompositeFuture.all(tenantId, deviceId)
+        Future.all(tenantId, deviceId)
             .compose(ok -> {
                 TracingHelper.setDeviceTags(span, tenantId.result(), deviceId.result());
                 logger.debug("retrieving device [tenant: {}, device-id: {}]", tenantId.result(), deviceId.result());
@@ -187,7 +186,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         final Future<List<Sort>> sortOptions = decodeJsonFromRequestParameter(ctx,
                 RegistryManagementConstants.PARAM_SORT_JSON, Sort.class);
 
-        CompositeFuture.all(pageSize, pageOffset, filters, sortOptions)
+        Future.all(pageSize, pageOffset, filters, sortOptions)
                 .onSuccess(ok -> TracingHelper.TAG_TENANT_ID.set(span, tenantId))
                 .compose(ok -> getService().searchDevices(
                         tenantId,
@@ -214,7 +213,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         final Future<String> deviceId = getRequestParameter(ctx, PARAM_DEVICE_ID, getPredicate(config.getDeviceIdPattern(), true));
         final Future<Device> device = fromPayload(ctx);
 
-        CompositeFuture.all(tenantId, deviceId, device)
+        Future.all(tenantId, deviceId, device)
             .compose(ok -> {
                 final Optional<String> did = Optional.ofNullable(deviceId.result());
                 TracingHelper.TAG_TENANT_ID.set(span, tenantId.result());
@@ -246,7 +245,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         final Future<String> deviceId = getRequestParameter(ctx, PARAM_DEVICE_ID, getPredicate(config.getDeviceIdPattern(), false));
         final Future<Device> device = fromPayload(ctx);
 
-        CompositeFuture.all(tenantId, deviceId, device)
+        Future.all(tenantId, deviceId, device)
             .compose(ok -> {
                 TracingHelper.setDeviceTags(span, tenantId.result(), deviceId.result());
                 logger.debug("updating device [tenant: {}, device-id: {}]", tenantId.result(), deviceId.result());
@@ -270,7 +269,7 @@ public class DelegatingDeviceManagementHttpEndpoint<S extends DeviceManagementSe
         final Future<String> tenantId = getRequestParameter(ctx, PARAM_TENANT_ID, getPredicate(config.getTenantIdPattern(), false));
         final Future<String> deviceId = getRequestParameter(ctx, PARAM_DEVICE_ID, getPredicate(config.getDeviceIdPattern(), false));
 
-        CompositeFuture.all(tenantId, deviceId)
+        Future.all(tenantId, deviceId)
             .compose(ok -> {
                 TracingHelper.setDeviceTags(span, tenantId.result(), deviceId.result());
                 logger.debug("removing device [tenant: {}, device-id: {}]", tenantId.result(), deviceId.result());

--- a/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/DelegatingTenantManagementHttpEndpoint.java
+++ b/services/device-registry-base/src/main/java/org/eclipse/hono/service/management/tenant/DelegatingTenantManagementHttpEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,6 @@ import org.eclipse.hono.tracing.TracingHelper;
 import org.eclipse.hono.util.RegistryManagementConstants;
 
 import io.opentracing.Span;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -162,7 +161,7 @@ public class DelegatingTenantManagementHttpEndpoint<S extends TenantManagementSe
         final Future<String> tenantId = getRequestParameter(ctx, PARAM_TENANT_ID, getPredicate(config.getTenantIdPattern(), true));
         final Future<Tenant> payload = fromPayload(ctx);
 
-        CompositeFuture.all(tenantId, payload)
+        Future.all(tenantId, payload)
             .compose(ok -> {
                 final Optional<String> tid = Optional.ofNullable(tenantId.result());
                 tid.ifPresent(s -> TracingHelper.TAG_TENANT_ID.set(span, s));
@@ -196,7 +195,7 @@ public class DelegatingTenantManagementHttpEndpoint<S extends TenantManagementSe
         final Future<String> tenantId = getRequestParameter(ctx, PARAM_TENANT_ID, getPredicate(config.getTenantIdPattern(), false));
         final Future<Tenant> payload = fromPayload(ctx);
 
-        CompositeFuture.all(tenantId, payload)
+        Future.all(tenantId, payload)
             .compose(tenant -> {
                 TracingHelper.TAG_TENANT_ID.set(span, tenantId.result());
                 logger.debug("updating tenant [{}]", tenantId.result());
@@ -252,7 +251,7 @@ public class DelegatingTenantManagementHttpEndpoint<S extends TenantManagementSe
         final Future<List<Sort>> sortOptions = decodeJsonFromRequestParameter(ctx,
                 RegistryManagementConstants.PARAM_SORT_JSON, Sort.class);
 
-        CompositeFuture.all(pageSize, pageOffset, filters, sortOptions)
+        Future.all(pageSize, pageOffset, filters, sortOptions)
                 .compose(ok -> getService().searchTenants(
                         pageSize.result(),
                         pageOffset.result(),

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/AbstractTenantManagementSearchTenantsTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/management/tenant/AbstractTenantManagementSearchTenantsTest.java
@@ -31,7 +31,6 @@ import org.eclipse.hono.util.Adapter;
 import org.junit.jupiter.api.Test;
 
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.junit5.VertxTestContext;
 
@@ -424,8 +423,7 @@ public interface AbstractTenantManagementSearchTenantsTest {
      */
     default Future<Void> createTenants(final Map<String, Tenant> tenantsToCreate) {
 
-        @SuppressWarnings("rawtypes")
-        final List<Future> creationResult = tenantsToCreate.entrySet().stream()
+        final List<Future<Object>> creationResult = tenantsToCreate.entrySet().stream()
                 .map(entry -> getTenantManagementService().createTenant(
                         Optional.of(entry.getKey()),
                         entry.getValue(),
@@ -435,6 +433,6 @@ public interface AbstractTenantManagementSearchTenantsTest {
                         return null;
                     }))
                 .collect(Collectors.toList());
-        return CompositeFuture.all(creationResult).mapEmpty();
+        return Future.all(creationResult).mapEmpty();
     }
 }

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,7 +36,6 @@ import org.eclipse.hono.util.RegistryManagementConstants;
 import org.junit.jupiter.api.Test;
 
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -812,7 +811,7 @@ public interface AbstractRegistrationServiceTest {
         final Future<RegistrationResult> f2 = gatewayId
                 .map(id -> getRegistrationService().assertRegistration(tenant, deviceId, id))
                 .orElseGet(() -> getRegistrationService().assertRegistration(tenant, deviceId));
-        return CompositeFuture.all(
+        return Future.all(
                 f1.otherwise(t -> OperationResult.empty(ServiceInvocationException.extractStatusCode(t)))
                     .map(r -> {
                         managementAssertions.handle(r);

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedTenantManagementSearchTenantsTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedTenantManagementSearchTenantsTest.java
@@ -30,7 +30,6 @@ import org.eclipse.hono.service.management.tenant.TenantWithId;
 import org.junit.jupiter.api.Test;
 
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.junit5.VertxTestContext;
 
@@ -44,8 +43,7 @@ class JdbcBasedTenantManagementSearchTenantsTest extends AbstractJdbcRegistryTes
      */
     private Future<Void> createTenants(final Map<String, Tenant> tenantsToCreate) {
 
-        @SuppressWarnings("rawtypes")
-        final List<Future> creationResult = tenantsToCreate.entrySet().stream()
+        final List<Future<Object>> creationResult = tenantsToCreate.entrySet().stream()
                 .map(entry -> getTenantManagementService().createTenant(
                         Optional.of(entry.getKey()),
                         entry.getValue(),
@@ -55,7 +53,7 @@ class JdbcBasedTenantManagementSearchTenantsTest extends AbstractJdbcRegistryTes
                         return null;
                     }))
                 .collect(Collectors.toList());
-        return CompositeFuture.all(creationResult).mapEmpty();
+        return Future.all(creationResult).mapEmpty();
     }
 
     /**

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/ResolveGroupsTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/ResolveGroupsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.junit5.VertxExtension;
@@ -159,7 +158,7 @@ class ResolveGroupsTest extends AbstractJdbcRegistryTest {
     @Test
     void testResolveGroups(final VertxTestContext context) {
 
-        CompositeFuture.all(Arrays.stream(testResolveGroups())
+        Future.all(Arrays.stream(testResolveGroups())
                 .map(test -> {
 
                     final var tenantId = UUID.randomUUID().toString();
@@ -168,7 +167,7 @@ class ResolveGroupsTest extends AbstractJdbcRegistryTest {
 
                             .flatMap(x -> this.tenantManagement.createTenant(Optional.of(tenantId), new Tenant(), SPAN))
 
-                            .flatMap(x -> CompositeFuture.all(
+                            .flatMap(x -> Future.all(
 
                                     test.devices.stream()
 

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.junit5.Timeout;
@@ -65,7 +65,7 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
         dao = MongoDbTestUtils.getDeviceDao(vertx, DB_NAME);
         credentialsDao = MongoDbTestUtils.getCredentialsDao(vertx, DB_NAME);
         service = new MongoDbBasedDeviceManagementService(vertx, dao, credentialsDao, config);
-        CompositeFuture.all(dao.createIndices(), credentialsDao.createIndices()).onComplete(testContext.succeedingThenComplete());
+        Future.all(dao.createIndices(), credentialsDao.createIndices()).onComplete(testContext.succeedingThenComplete());
     }
 
     /**
@@ -85,7 +85,7 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
      */
     @AfterEach
     public void cleanCollection(final VertxTestContext testContext) {
-        CompositeFuture.all(
+        Future.all(
                 dao.deleteAllFromCollection(),
                 credentialsDao.deleteAllFromCollection())
             .onComplete(testContext.succeedingThenComplete());
@@ -104,7 +104,7 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
         final Promise<Void> credentialsCloseHandler = Promise.promise();
         credentialsDao.close(credentialsCloseHandler);
 
-        CompositeFuture.all(credentialsCloseHandler.future(), devicesCloseHandler.future())
+        Future.all(credentialsCloseHandler.future(), devicesCloseHandler.future())
             .compose(ok -> {
                 final Promise<Void> vertxCloseHandler = Promise.promise();
                 vertx.close(vertxCloseHandler);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -56,7 +56,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -115,7 +114,7 @@ public class MongoDbBasedCredentialServiceTest implements CredentialsServiceTest
                 credentialsDao,
                 registrationServiceConfig);
 
-        CompositeFuture.all(deviceDao.createIndices(), credentialsDao.createIndices())
+        Future.all(deviceDao.createIndices(), credentialsDao.createIndices())
             .onComplete(ctx.succeedingThenComplete());
     }
 
@@ -170,7 +169,7 @@ public class MongoDbBasedCredentialServiceTest implements CredentialsServiceTest
         final Promise<Void> deviceCloseHandler = Promise.promise();
         deviceDao.close(deviceCloseHandler);
 
-        CompositeFuture.all(credentialsCloseHandler.future(), deviceCloseHandler.future())
+        Future.all(credentialsCloseHandler.future(), deviceCloseHandler.future())
             .compose(ok -> {
                 final Promise<Void> vertxCloseHandler = Promise.promise();
                 vertx.close(vertxCloseHandler);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -54,7 +54,6 @@ import org.slf4j.LoggerFactory;
 import io.opentracing.Span;
 import io.opentracing.noop.NoopSpan;
 import io.opentracing.noop.NoopTracerFactory;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -106,7 +105,7 @@ public class MongoDbBasedRegistrationServiceTest implements AbstractRegistration
         registrationService = new MongoDbBasedRegistrationService(deviceDao);
         registrationService.setEdgeDeviceAutoProvisioner(edgeDeviceAutoProvisioner);
 
-        CompositeFuture.all(deviceDao.createIndices(), credentialsDao.createIndices()).onComplete(testContext.succeedingThenComplete());
+        Future.all(deviceDao.createIndices(), credentialsDao.createIndices()).onComplete(testContext.succeedingThenComplete());
     }
 
     /**
@@ -140,7 +139,7 @@ public class MongoDbBasedRegistrationServiceTest implements AbstractRegistration
      */
     @AfterEach
     public void cleanCollection(final VertxTestContext testContext) {
-        CompositeFuture.all(
+        Future.all(
                 deviceDao.deleteAllFromCollection(),
                 credentialsDao.deleteAllFromCollection())
             .onComplete(testContext.succeedingThenComplete());
@@ -158,7 +157,7 @@ public class MongoDbBasedRegistrationServiceTest implements AbstractRegistration
         final Promise<Void> deviceCloseHandler = Promise.promise();
         deviceDao.close(deviceCloseHandler);
 
-        CompositeFuture.all(credentialsCloseHandler.future(), deviceCloseHandler.future())
+        Future.all(credentialsCloseHandler.future(), deviceCloseHandler.future())
             .compose(ok -> {
                 final Promise<Void> vertxCloseHandler = Promise.promise();
                 vertx.close(vertxCloseHandler);

--- a/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/IntegrationTestSupport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -92,7 +92,6 @@ import io.opentelemetry.opentracingshim.OpenTracingShim;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentracing.Tracer;
 import io.opentracing.noop.NoopSpan;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -928,7 +927,7 @@ public final class IntegrationTestSupport {
         if (!devicesToDelete.isEmpty()) {
             LOGGER.debug("deleting {} temporary devices ...", devicesToDelete.size());
         }
-        final var deleteDevices = CompositeFuture
+        final var deleteDevices = Future
                 .join(devicesToDelete.entrySet()
                         .stream().flatMap(entry ->
                                 entry.getValue().stream()
@@ -946,7 +945,7 @@ public final class IntegrationTestSupport {
                     if (!tenantsToDelete.isEmpty()) {
                         LOGGER.debug("deleting {} temporary tenants ...", tenantsToDelete.size());
                     }
-                    return CompositeFuture.join(tenantsToDelete.stream()
+                    return Future.join(tenantsToDelete.stream()
                                     .map(tenantId -> registry.removeTenant(tenantId, true))
                                     .collect(Collectors.toList()));
                 })
@@ -1234,7 +1233,7 @@ public final class IntegrationTestSupport {
                     timeOutTracker.tryComplete();
                 });
 
-        return CompositeFuture.all(sendCommandTracker, timeOutTracker.future())
+        return Future.all(sendCommandTracker, timeOutTracker.future())
                 .recover(error -> {
                     LOGGER.debug("got error sending command: {}", error.getMessage());
                     return Future.failedFuture(error);
@@ -1309,7 +1308,7 @@ public final class IntegrationTestSupport {
                     }
                 });
 
-        return CompositeFuture.all(sendOneWayCommandTracker, timeOutTracker.future())
+        return Future.all(sendOneWayCommandTracker, timeOutTracker.future())
                 .mapEmpty();
     }
 
@@ -1541,7 +1540,7 @@ public final class IntegrationTestSupport {
 
         final Promise<Void> provisioningMessageReceived = Promise.promise();
         final Promise<Void> telemetryMessageReceived = Promise.promise();
-        CompositeFuture.all(provisioningMessageReceived.future(), telemetryMessageReceived.future())
+        Future.all(provisioningMessageReceived.future(), telemetryMessageReceived.future())
             .onSuccess(ok -> resultHandler.complete())
             .onFailure(t -> resultHandler.fail(t));
 

--- a/tests/src/test/java/org/eclipse/hono/tests/auth/AuthServerAmqpIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/auth/AuthServerAmqpIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -124,7 +124,7 @@ public class AuthServerAmqpIT {
 
         final var token = client.verifyPlain(null, "hono-client", "secret");
 
-        CompositeFuture.all(validationKey, token)
+        Future.all(validationKey, token)
             .onComplete(ctx.succeeding(ok -> {
                 final var user = token.result();
                 LOG.debug("retrieved token:{}{}", System.lineSeparator(), user.getToken());

--- a/tests/src/test/java/org/eclipse/hono/tests/client/HonoKafkaConsumerIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/client/HonoKafkaConsumerIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -50,7 +50,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -675,21 +674,19 @@ public class HonoKafkaConsumerIT {
     }
 
     private Future<Void> publishRecords(final int numTestRecordsPerTopic, final String keyPrefix, final Set<String> topics) {
-        @SuppressWarnings("rawtypes")
-        final List<Future> resultFutures = new ArrayList<>();
+        final List<Future<Void>> resultFutures = new ArrayList<>();
         topics.forEach(topic -> {
             resultFutures.add(publishRecords(numTestRecordsPerTopic, keyPrefix, topic));
         });
-        return CompositeFuture.all(resultFutures).map((Void) null);
+        return Future.all(resultFutures).map((Void) null);
     }
 
     private Future<Void> publishRecords(final int numRecords, final String keyPrefix, final String topic) {
-        @SuppressWarnings("rawtypes")
-        final List<Future> resultFutures = new ArrayList<>();
+        final List<Future<Void>> resultFutures = new ArrayList<>();
         IntStream.range(0, numRecords).forEach(i -> {
             resultFutures.add(publish(topic, keyPrefix + i, Buffer.buffer("testPayload")).mapEmpty());
         });
-        return CompositeFuture.all(resultFutures).map((Void) null);
+        return Future.all(resultFutures).map((Void) null);
     }
 
     private static Future<RecordMetadata> publish(final String topic, final String recordKey, final Buffer recordPayload) {

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -63,7 +63,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.handler.codec.http.QueryStringEncoder;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -1206,7 +1205,7 @@ public abstract class HttpTestBase {
         logger.info("sent one-way command to device");
 
         // THEN both requests succeed
-        CompositeFuture.all(commandSent, firstRequest, secondRequest)
+        Future.all(commandSent, firstRequest, secondRequest)
         .onComplete(ctx.succeeding(ok -> {
             ctx.verify(() -> {
                 // and the response to the second request contains a command

--- a/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/mqtt/MqttPublishTestBase.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.Test;
 import io.netty.handler.codec.http.QueryStringEncoder;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
@@ -609,7 +608,7 @@ public abstract class MqttPublishTestBase extends MqttTestBase {
                     // WHEN a device publishes a message with a payload exceeding the max size
                     final Future<Integer> sendFuture = send(tenantId, deviceId, Buffer.buffer(payloadBytes), false,
                             true, null);
-                    return CompositeFuture.join(clientClosedPromise.future(), sendFuture)
+                    return Future.join(clientClosedPromise.future(), sendFuture)
                             .onComplete(ar -> {
                                 // THEN publishing the message fails (if QoS 1)
                                 if (getQos() == MqttQoS.AT_LEAST_ONCE) {

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceManagementIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
@@ -625,7 +625,7 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
 
             final int pageSize = 1;
 
-            CompositeFuture.all(
+            Future.all(
                     registry.registerDevice(tenantId, getHelper().getRandomDeviceId(tenantId), new Device()),
                     registry.registerDevice(tenantId, getHelper().getRandomDeviceId(tenantId), new Device()))
                 .compose(response -> registry.searchDevices(
@@ -677,7 +677,7 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
             final int pageOffset = 1;
             final String sortJson = getSortJson("/ext/id", "desc");
 
-            CompositeFuture.all(
+            Future.all(
                     registry.registerDevice(tenantId, deviceId1, device1),
                     registry.registerDevice(tenantId, deviceId2, device2))
                 .compose(ok -> registry.searchDevices(tenantId, Optional.of(pageSize), Optional.of(pageOffset),
@@ -723,7 +723,7 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
             final String filterJson2 = getFilterJson("/enabled", true, "eq");
             final String filterJson3 = getFilterJson("/enabled", false, "eq");
 
-            CompositeFuture.all(
+            Future.all(
                     registry.registerDevice(tenantId, deviceId1, device1),
                     registry.registerDevice(tenantId, deviceId2, device2))
                 .compose(ok -> registry.searchDevices(tenantId, Optional.empty(), Optional.empty(),
@@ -757,7 +757,7 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
             final String filterJson1 = getFilterJson("/enabled", true, "eq");
             final String filterJson2 = getFilterJson("/ext/id", "$id*", "eq");
 
-            CompositeFuture.all(
+            Future.all(
                     registry.registerDevice(tenantId, deviceId1, device1),
                     registry.registerDevice(tenantId, deviceId2, device2))
                 .compose(ok -> registry.searchDevices(tenantId, Optional.empty(), Optional.empty(),
@@ -807,7 +807,7 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
             final String filterJson1 = getFilterJson("/enabled", true, "eq");
             final String filterJson2 = getFilterJson("/ext/id", "$id?2", "eq");
 
-            CompositeFuture.all(
+            Future.all(
                     registry.registerDevice(tenantId, deviceId1, device1),
                     registry.registerDevice(tenantId, deviceId2, device2))
                 .compose(ok -> registry.searchDevices(tenantId, Optional.empty(), Optional.empty(),
@@ -870,7 +870,7 @@ public class DeviceManagementIT extends DeviceRegistryTestBase {
             final Device device2 = new Device().setExtensions(Map.of("id", "bbb"));
             final String sortJson = getSortJson("/ext/id", "desc");
 
-            CompositeFuture.all(
+            Future.all(
                     registry.registerDevice(tenantId, deviceId1, device1),
                     registry.registerDevice(tenantId, deviceId2, device2))
                 .compose(ok -> registry.searchDevices(tenantId, Optional.empty(), Optional.empty(), List.of(),

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryNotificationsIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/DeviceRegistryNotificationsIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -94,7 +93,7 @@ public class DeviceRegistryNotificationsIT {
         final Future<Void> receiverStopFuture = Optional.ofNullable(receiver)
                 .map(Lifecycle::stop)
                 .orElseGet(Future::succeededFuture);
-        CompositeFuture.join(receiverStopFuture, helper.disconnect())
+        Future.join(receiverStopFuture, helper.disconnect())
             .onComplete(ar -> helper.deleteObjects(ctx));
     }
 

--- a/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/registry/TenantManagementIT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpHeaders;
@@ -850,7 +849,7 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
 
             final int pageSize = 1;
 
-            CompositeFuture.all(
+            Future.all(
                     getHelper().registry.addTenant(getHelper().getRandomTenantId(), new Tenant()),
                     getHelper().registry.addTenant(getHelper().getRandomTenantId(), new Tenant()))
                     .compose(response -> getHelper().registry.searchTenants(
@@ -973,7 +972,7 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
             final String filterJson2 = getFilterJson("/enabled", true, "eq");
             final String filterJson3 = getFilterJson("/enabled", false, "eq");
 
-            CompositeFuture.all(
+            Future.all(
                     getHelper().registry.addTenant(tenantId1, tenant1),
                     getHelper().registry.addTenant(tenantId2, tenant2))
                     .compose(ok -> getHelper().registry.searchTenants(Optional.empty(), Optional.empty(),
@@ -1008,7 +1007,7 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
             final String filterJson1 = getFilterJson("/enabled", true, "eq");
             final String filterJson2 = getFilterJson("/ext/id", "$id*", "eq");
 
-            CompositeFuture.all(
+            Future.all(
                     getHelper().registry.addTenant(tenantId1, tenant1),
                     getHelper().registry.addTenant(tenantId2, tenant2))
                     .compose(ok -> getHelper().registry.searchTenants(Optional.empty(), Optional.empty(),
@@ -1058,7 +1057,7 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
             final String filterJson1 = getFilterJson("/enabled", true, "eq");
             final String filterJson2 = getFilterJson("/ext/id", "$id?2", "eq");
 
-            CompositeFuture.all(
+            Future.all(
                     getHelper().registry.addTenant(tenantId1, tenant1),
                     getHelper().registry.addTenant(tenantId2, tenant2))
                     .compose(ok -> getHelper().registry.searchTenants(Optional.empty(), Optional.empty(),
@@ -1121,7 +1120,7 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
             final Tenant tenant2 = new Tenant().setExtensions(Map.of("id", "bbb"));
             final String sortJson = getSortJson("/ext/id", "desc");
 
-            CompositeFuture.all(
+            Future.all(
                     getHelper().registry.addTenant(tenantId1, tenant1),
                     getHelper().registry.addTenant(tenantId2, tenant2))
                     .compose(ok -> getHelper().registry.searchTenants(Optional.empty(), Optional.empty(), List.of(),
@@ -1148,15 +1147,14 @@ public class TenantManagementIT extends DeviceRegistryTestBase {
          */
         private Future<Void> createTenants(final Map<String, Tenant> tenantsToCreate) {
 
-            @SuppressWarnings("rawtypes")
-            final List<Future> creationResult = tenantsToCreate.entrySet().stream()
+            final List<Future<Object>> creationResult = tenantsToCreate.entrySet().stream()
                     .map(entry -> getHelper().registry.addTenant(entry.getKey(), entry.getValue())
                         .map(response -> {
                             assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_CREATED);
                             return null;
                         }))
                     .collect(Collectors.toList());
-            return CompositeFuture.all(creationResult).mapEmpty();
+            return Future.all(creationResult).mapEmpty();
         }
 
         private <T> String getFilterJson(final String field, final T value, final String operator) {


### PR DESCRIPTION
Changed all direct `CompositeFuture` static create method calls to corresponding method calls in `Future` instead. If not yet they all are deprecated in latest Vert.x version.