### PR TITLE
Fix NPE when running CLI

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
@@ -41,6 +41,7 @@ import org.eclipse.hono.client.command.CommandConsumer;
 import org.eclipse.hono.client.device.amqp.AmqpAdapterClient;
 import org.eclipse.hono.util.QoS;
 import org.fusesource.jansi.AnsiConsole;
+import org.jline.builtins.ConfigurationPath;
 import org.jline.console.SystemRegistry;
 import org.jline.console.impl.Builtins;
 import org.jline.console.impl.SystemRegistryImpl;
@@ -252,7 +253,7 @@ public class AmqpAdapter implements Callable<Integer> {
         try {
             final Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
             // set up JLine built-in commands
-            final var builtins = new Builtins(workDir, null, null);
+            final var builtins = new Builtins(workDir, new ConfigurationPath(null, null), null);
             builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");

--- a/cli/src/main/java/org/eclipse/hono/cli/app/CommandAndControl.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/CommandAndControl.java
@@ -34,6 +34,7 @@ import org.eclipse.hono.client.ServiceInvocationException;
 import org.eclipse.hono.util.Constants;
 import org.eclipse.hono.util.MessageHelper;
 import org.fusesource.jansi.AnsiConsole;
+import org.jline.builtins.ConfigurationPath;
 import org.jline.console.SystemRegistry;
 import org.jline.console.impl.Builtins;
 import org.jline.console.impl.SystemRegistryImpl;
@@ -162,7 +163,7 @@ public class CommandAndControl implements Callable<Integer> {
         try {
             final Supplier<Path> workDir = () -> Paths.get(System.getProperty("user.dir"));
             // set up JLine built-in commands
-            final var builtins = new Builtins(workDir, null, null);
+            final var builtins = new Builtins(workDir, new ConfigurationPath(null, null), null);
             builtins.rename(Builtins.Command.TTOP, "top");
             builtins.alias("zle", "widget");
             builtins.alias("bindkey", "keymap");

--- a/cli/src/main/java/org/eclipse/hono/cli/util/ConnectionOptions.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/util/ConnectionOptions.java
@@ -59,7 +59,7 @@ public class ConnectionOptions {
             names = { "--ca-file" },
             description = {
                 "Absolute path to a file containing trusted CA certificates to enable encrypted communication.",
-                "If not set explicitly, the platform's default trust store will be used."
+                "This option is required for connecting to endpoints using TLS."
                 },
             order = 4)
     public Optional<String> trustStorePath;


### PR DESCRIPTION
The AmqpAdapter and CommandAndControl classes have been changed to pass in a non-null ConfigurationPath when creating the JLine console builtins.

Fixes #3576