### PR TITLE
Remove CLI ca-file requirement for sandbox connections.

### DIFF
--- a/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/adapter/amqp/AmqpAdapter.java
@@ -186,16 +186,8 @@ public class AmqpAdapter implements Callable<Integer> {
     }
 
     private void validateConnectionOptions() {
-        if (connectionOptions.useSandbox) {
-            if (!connectionOptions.trustStorePath.isPresent()) {
-                throw new ParameterException(
-                        spec.commandLine(),
-                        """
-                        Missing required option: '--ca-file=<path>' needs to be specified \
-                        when using '--sandbox'.
-                        """);
-            }
-        } else if (connectionOptions.hostname.isEmpty() || connectionOptions.portNumber.isEmpty()) {
+        if (!connectionOptions.useSandbox
+                && (connectionOptions.hostname.isEmpty() || connectionOptions.portNumber.isEmpty())) {
             throw new ParameterException(
                     spec.commandLine(),
                     """
@@ -227,6 +219,7 @@ public class AmqpAdapter implements Callable<Integer> {
         if (connectionOptions.useSandbox) {
             clientConfig.setHost(ConnectionOptions.SANDBOX_HOST_NAME);
             clientConfig.setPort(5671);
+            clientConfig.setTlsEnabled(true);
             Optional.ofNullable(connectionOptions.credentials).ifPresentOrElse(
                     creds -> {
                         clientConfig.setUsername(creds.username);

--- a/cli/src/main/java/org/eclipse/hono/cli/app/NorthBoundApis.java
+++ b/cli/src/main/java/org/eclipse/hono/cli/app/NorthBoundApis.java
@@ -99,16 +99,8 @@ public class NorthBoundApis {
     ApplicationClient<? extends MessageContext> client;
 
     private void validateConnectionOptions() {
-        if (connectionOptions.useSandbox) {
-            if (!connectionOptions.trustStorePath.isPresent()) {
-                throw new ParameterException(
-                        spec.commandLine(),
-                        """
-                        Missing required option: '--ca-file=<path>' needs to be specified \
-                        when using '--sandbox'.
-                        """);
-            }
-        } else if (connectionOptions.hostname.isEmpty() || connectionOptions.portNumber.isEmpty()) {
+        if (!connectionOptions.useSandbox
+                && (connectionOptions.hostname.isEmpty() || connectionOptions.portNumber.isEmpty())) {
             throw new ParameterException(
                     spec.commandLine(),
                     """
@@ -211,6 +203,7 @@ public class NorthBoundApis {
         if (connectionOptions.useSandbox) {
             clientConfig.setHost(ConnectionOptions.SANDBOX_HOST_NAME);
             clientConfig.setPort(15671);
+            clientConfig.setTlsEnabled(true);
             clientConfig.setUsername(SANDBOX_AMQP_USER);
             clientConfig.setPassword(SANDBOX_AMQP_PWD);
         } else {

--- a/examples/quickstart-python/quickstart.py
+++ b/examples/quickstart-python/quickstart.py
@@ -35,7 +35,7 @@ amqp_network_ip = HONO_SANDBOX_HOSTNAME
 tenant = requests.post(
     url=f"{registry_base_url}/tenants",
     headers={"content-type": "application/json"},
-    data=json.dumps({"ext": { "messaging-type": "kafka" }})).json()
+    data=json.dumps({"ext": {"messaging-type": "kafka"}})).json()
 tenant_id = tenant["id"]
 
 print(f"Registered tenant {tenant_id}")
@@ -61,7 +61,7 @@ else:
 # Now we can start the client application
 print("You could now start the Hono Command Line Client in another terminal to consume messages from devices:")
 print()
-cmd = f"java -jar hono-cli-2.*-exec.jar app --sandbox --ca-file {CA_FILE} consume --tenant={tenant_id}"
+cmd = f"java -jar hono-cli-2.*-exec.jar app --sandbox consume --tenant={tenant_id}"
 print(cmd)
 print()
 
@@ -103,10 +103,12 @@ class DownstreamApp(threading.Thread):
 
         consumer.close()
 
+
 task = DownstreamApp()
 task.start()
 # wait for topic to be created
 time.sleep(3)
+
 
 def send_message_via_http_adapter():
     # nosemgrep: no-auth-over-http

--- a/site/documentation/content/getting-started/_index.md
+++ b/site/documentation/content/getting-started/_index.md
@@ -48,6 +48,10 @@ The command line client is available in two variants:
 The former variant works on all platforms where Java is available and will be used during the remainder of this guide.
 The latter variant should work on modern Linux distributions and can be used by replacing `java -jar hono-cli-*-exec.jar`
 with just the name of the executable file.
+
+Note that when using the native executable, the root CA certificates included in the executable will be used. To use the
+(possibly more up to date) local CA certificates instead, add the `--ca-file` CLI parameter with the path of the
+certificates (e.g. `--ca-file /etc/ssl/certs/ca-certificates.crt`).
 {{% /notice %}}
 
 #### Hono Instance
@@ -120,7 +124,7 @@ export REGISTRY_IP=hono.eclipseprojects.io
 export HTTP_ADAPTER_IP=hono.eclipseprojects.io
 export MQTT_ADAPTER_IP=hono.eclipseprojects.io
 export KAFKA_IP=hono.eclipseprojects.io
-export APP_OPTIONS="--sandbox --ca-file /etc/ssl/certs/ca-certificates.crt"
+export APP_OPTIONS="--sandbox"
 export CURL_OPTIONS=
 export MOSQUITTO_OPTIONS='--cafile /etc/ssl/certs/ca-certificates.crt'
 EOS
@@ -136,7 +140,7 @@ export REGISTRY_IP=hono.eclipseprojects.io
 export HTTP_ADAPTER_IP=hono.eclipseprojects.io
 export MQTT_ADAPTER_IP=hono.eclipseprojects.io
 export KAFKA_IP=hono.eclipseprojects.io
-export APP_OPTIONS="--sandbox --ca-file /etc/ssl/certs/ca-certificates.crt"
+export APP_OPTIONS="--sandbox"
 export CURL_OPTIONS=
 export MOSQUITTO_OPTIONS='--cafile /etc/ssl/certs/ca-certificates.crt'
 ~~~

--- a/site/documentation/content/user-guide/amqp-adapter.md
+++ b/site/documentation/content/user-guide/amqp-adapter.md
@@ -120,8 +120,8 @@ delivery semantics as described in the following sections.
 The AMQP adapter distinguishes between two types of errors when a message is published using *AT LEAST ONCE* delivery
 semantics:
 
-* An error caused by the client side, e.g invalid message address, content-type, adapter disabled for tenant etc.
-* An error caused by the server side, e.g no downstream consumers registered, downstream connection loss etc.
+* An error caused by the client side, e.g. invalid message address, content-type, adapter disabled for tenant etc.
+* An error caused by the server side, e.g. no downstream consumers registered, downstream connection loss etc.
 
 For a client side error, the adapter settles the message transfer with the *rejected* outcome and provides an error
 description in the corresponding disposition frame. In the case of a server-side error, the adapter settles the
@@ -148,7 +148,7 @@ adapter and prompts the user for a command to execute:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt
+java -jar hono-cli-*-exec.jar amqp --sandbox
 ~~~
 ~~~
 hono-cli/amqp-device>
@@ -213,7 +213,7 @@ Start the client in interactive mode:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt
+java -jar hono-cli-*-exec.jar amqp --sandbox
 ~~~
 ~~~
 hono-cli/amqp-device>
@@ -236,7 +236,7 @@ The message can also be sent in non-interactive mode:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt telemetry --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox telemetry --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 Note that sending the message this way will take a little longer than in interactive mode because the connection to the
@@ -282,7 +282,7 @@ publishing some JSON data on behalf of device `4711` of tenant `DEFAULT_TENANT` 
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt telemetry --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox telemetry --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -334,7 +334,7 @@ some JSON data on behalf of device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt -u gw@DEFAULT_TENANT -p gw-secret telemetry --device 4712 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox -u gw@DEFAULT_TENANT -p gw-secret telemetry --device 4712 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -386,7 +386,7 @@ Publish a JSON string for the authenticated device (`4711`):
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt event --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox event --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 ## Publish an Event (unauthenticated Device)
@@ -427,7 +427,7 @@ publishing some JSON data on behalf of device `4711` of tenant `DEFAULT_TENANT` 
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt event --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox event --tenant DEFAULT_TENANT --device 4711 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -472,7 +472,7 @@ some JSON data on behalf of device `4712`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt -u gw@DEFAULT_TENANT -p gw-secret event --device 4712 --payload '{"foo": "bar"}' --content-type application/json
+java -jar hono-cli-*-exec.jar amqp --sandbox -u gw@DEFAULT_TENANT -p gw-secret event --device 4712 --payload '{"foo": "bar"}' --content-type application/json
 ~~~
 
 {{% notice info %}}
@@ -604,7 +604,7 @@ Start the client in interactive mode:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar amqp --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt 
+java -jar hono-cli-*-exec.jar amqp --sandbox 
 hono-cli/amqp-device>
 ~~~
 
@@ -651,7 +651,7 @@ command to send a request-response command to device `4711`:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar app --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt command req -d 4711 -n setColor --payload '{"r": 128,"g": 100,"b": 50}'
+java -jar hono-cli-*-exec.jar app --sandbox command req -d 4711 -n setColor --payload '{"r": 128,"g": 100,"b": 50}'
 ~~~
 
 This will result in the device's response being printed to the console:
@@ -664,7 +664,7 @@ It is also possible to send a one-way command:
 
 ~~~sh
 # in directory: hono/cli/target/
-java -jar hono-cli-*-exec.jar app --sandbox --ca-file /etc/ssl/certs/ca-certificates.crt command ow -d 4711 -n setVolume --payload '{"level": 50}'
+java -jar hono-cli-*-exec.jar app --sandbox command ow -d 4711 -n setVolume --payload '{"level": 50}'
 ~~~
 
 ## Downstream Meta Data


### PR DESCRIPTION
Follow-up of #3570:
The CLI `--ca-file` parameter shouldn't be required when connecting to the sandbox.