### PR TITLE
[#3555] Device Registry JDBC native build

### DIFF
--- a/.github/workflows/native-images-tests.yml
+++ b/.github/workflows/native-images-tests.yml
@@ -45,7 +45,7 @@ jobs:
         mvn install -B -e -DskipTests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
         -Dquarkus.native.remote-container-build=false -Dquarkus.native.container-build=true \
         -Pbuild-native-image,metrics-prometheus -am \
-        -pl :hono-service-auth,:hono-service-command-router,:hono-service-device-registry-mongodb,\
+        -pl :hono-service-auth,:hono-service-command-router,:hono-service-device-registry-mongodb,:hono-service-device-registry-jdbc,\
         :hono-adapter-mqtt,:hono-adapter-amqp,:hono-adapter-coap,:hono-adapter-http,:hono-adapter-lora,\
         :hono-tests
     - name: "Run integration tests with Mongo DB and Kafka"
@@ -54,10 +54,12 @@ jobs:
         -Dhono.components.type=quarkus-native -Dhono.deviceregistry.type=mongodb \
         -Dhono.messaging-infra.type=kafka -Dhono.commandrouting.cache=server \
         -Prun-tests,jaeger
-    - name: "Build JDBC registry image"
+    - name: "Run integration tests with PostgreSQL DB and Kafka"
       run: |
-        mvn install -B -e -DskipTests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-        -Pbuild-docker-image,metrics-prometheus -am -pl :hono-service-device-registry-jdbc
+        mvn verify -pl :hono-tests -B -e -DCI=$CI \
+        -Dhono.components.type=quarkus-native -Dhono.deviceregistry.type=jdbc \
+        -Dhono.messaging-infra.type=kafka -Dhono.commandrouting.cache=server \
+        -Prun-tests,jaeger
     - name: "Run integration tests with Sandbox-like configuration"
       run: |
         mvn verify -pl :hono-tests -B -e -DCI=$CI \

--- a/services/base-jdbc/src/main/resources/META-INF/native-image/org/eclipse/hono/hono-service-base-jdbc/native-image.properties
+++ b/services/base-jdbc/src/main/resources/META-INF/native-image/org/eclipse/hono/hono-service-base-jdbc/native-image.properties
@@ -1,0 +1,12 @@
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+Args = -H:ResourceConfigurationResources=${.}/resources-config.json

--- a/services/base-jdbc/src/main/resources/META-INF/native-image/org/eclipse/hono/hono-service-base-jdbc/resources-config.json
+++ b/services/base-jdbc/src/main/resources/META-INF/native-image/org/eclipse/hono/hono-service-base-jdbc/resources-config.json
@@ -1,0 +1,8 @@
+{
+  "resources": {
+    "includes": [
+      { "pattern":  "org\\/eclipse\\/hono\\/service\\/base\\/jdbc\\/store\\/.*\\.yaml$" },
+      { "pattern":  "sql\\/.*\\.sql$" }
+    ]
+  }
+}

--- a/services/device-registry-jdbc/pom.xml
+++ b/services/device-registry-jdbc/pom.xml
@@ -191,14 +191,14 @@
 
     <profile>
       <id>build-native-image</id>
-      <!--
-         Currently we do not support compiling a native executable because it does not work with
-         H2 in embedded mode. We can either drop support for H2 in embedded mode in the native image
-         or always use the JVM based version.
-      -->
-      <properties>
-        <quarkus.package.type>jar</quarkus.package.type>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -117,11 +117,13 @@
     <hono.deviceregistry.mongodb.native-image-args></hono.deviceregistry.mongodb.native-image-args>
 
     <hono.deviceregistry.jdbc.disabled>true</hono.deviceregistry.jdbc.disabled>
+    <hono.deviceregistry.jdbc.image>hono-service-device-registry-jdbc</hono.deviceregistry.jdbc.image>
     <hono.deviceregistry.jdbc.max-mem>400000000</hono.deviceregistry.jdbc.max-mem>
     <hono.deviceregistry.jdbc.java-options>
       ${default.java-options}
       -Dorg.eclipse.hono.service.base.jdbc.store.skipDumpingStatementConfiguration=true
     </hono.deviceregistry.jdbc.java-options>
+    <hono.deviceregistry.jdbc.native-image-args></hono.deviceregistry.jdbc.native-image-args>
 
     <!--  accept requests with a body size of up to 2000 bytes -->
     <hono.deviceregistry.maxPayloadSize>2000</hono.deviceregistry.maxPayloadSize>
@@ -636,6 +638,8 @@
         <hono.command-router.max-mem>100000000</hono.command-router.max-mem>
         <hono.deviceregistry.mongodb.image>hono-service-device-registry-mongodb-native</hono.deviceregistry.mongodb.image>
         <hono.deviceregistry.mongodb.max-mem>150000000</hono.deviceregistry.mongodb.max-mem>
+        <hono.deviceregistry.jdbc.image>hono-service-device-registry-jdbc-native</hono.deviceregistry.jdbc.image>
+        <hono.deviceregistry.jdbc.max-mem>150000000</hono.deviceregistry.jdbc.max-mem>
       </properties>
     </profile>
     <profile>
@@ -1425,7 +1429,7 @@
                   <build>
                     <skip>${hono.deviceregistry.jdbc.disabled}</skip>
                     <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                    <from>${docker.repository}/hono-service-device-registry-jdbc:${project.version}</from>
+                    <from>${docker.repository}/${hono.deviceregistry.jdbc.image}:${project.version}</from>
                     <assembly>
                       <mode>dir</mode>
                       <basedir>/</basedir>
@@ -1465,6 +1469,11 @@
                       <name>${custom.network.name}</name>
                       <alias>${hono.registration.host}</alias>
                     </network>
+                    <cmd>
+                      <exec>
+                        <arg>${hono.deviceregistry.jdbc.native-image-args}</arg>
+                      </exec>
+                    </cmd>
                     <memorySwap>${hono.deviceregistry.jdbc.max-mem}</memorySwap>
                     <memory>${hono.deviceregistry.jdbc.max-mem}</memory>
                     <env>


### PR DESCRIPTION
Changes needed for device registry JDBC to make native-image build succeeds and native-image integration tests run passes.