### PR TITLE
Use KRaft mode for Sandbox deployment

### DIFF
--- a/deploy/src/main/sandbox/hono-values.yml
+++ b/deploy/src/main/sandbox/hono-values.yml
@@ -205,58 +205,45 @@ commandRouterService:
     limits:
       memory: "120Mi"
 
+# assumes bitnami/kafka chart version ^26.8
 kafka:
-  ## @param logFlushIntervalMessages The number of messages to accept before forcing a flush of data to disk
-  ##
-  logFlushIntervalMessages: _1000
-  ## @param logFlushIntervalMs The maximum amount of time a message can sit in a log before we force a flush
-  ##
-  logFlushIntervalMs: 1000
-  ## @param logRetentionBytes A size-based retention policy for logs
-  ## 10MB
-  logRetentionBytes: _10485760
-  ## @param logRetentionCheckIntervalMs The interval at which log segments are checked to see if they can be deleted
-  ##
-  logRetentionCheckIntervalMs: 300000
-  ## @param logRetentionHours The minimum age of a log file to be eligible for deletion due to age
-  ##
-  logRetentionHours: 1
-  ## @param logSegmentBytes The maximum size of a log segment file. When this size is reached a new log segment will be created
-  ## 10MB
-  logSegmentBytes: _10485760
-  auth:
-    tls:
-      type: "pem"
-      pemChainIncluded: true
-      existingSecrets:
-      - "sandbox-tls"
+  controller:
+    extraConfig: |
+      group.initial.rebalance.delay.ms=0
+      offsets.topic.replication.factor=1
+      transaction.state.log.min.isr=1
+      transaction.state.log.replication.factor=1
+      log.flush.interval.messages=1000
+      log.flush.interval.ms=1000
+      log.retention.bytes=10485760
+      log.retention.check.interval.ms=300000
+      log.retention.hours=1
+      log.segment.bytes=10485760
+  tls:
+    type: "PEM"
+    pemChainIncluded: true
+    existingSecret: "sandbox-tls"
   externalAccess:
+    enabled: true
     autoDiscovery:
       enabled: false
-    service:
-      type: "LoadBalancer"
-      loadBalancerIPs:
-      - "hono.eclipseprojects.io"
-      nodePorts: []
+    broker:
+      service:
+        type: "LoadBalancer"
+        loadBalancerIPs:
+        - "hono.eclipseprojects.io"
+        nodePorts: []
+    controller:
+      service:
+        type: "LoadBalancer"
+        loadBalancerIPs:
+        - "hono.eclipseprojects.io"
+        nodePorts: []
+
   serviceAccount:
     create: false
   rbac:
     create: false
-  heapOpts: "-Xms650M -Xmx650M"
-  resources:
-    requests:
-      cpu: "50m"
-      memory: "800Mi"
-    limits:
-      memory: "800Mi"
-  zookeeper:
-    heapSize: 300
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "400Mi"
-      limits:
-        memory: "400Mi"
 
 jaegerBackendExample:
   enabled: false


### PR DESCRIPTION
Adapted Kafka configuration properties to use single node Kafka instance in KRaft mode based on bitnami/kafka chart version ^26.8.