### PR TITLE
[#3608] Verify that auto-provisioned device ids match device id pattern

### DIFF
--- a/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/deviceregistry/service/device/AbstractDeviceManagementServiceTest.java
@@ -28,6 +28,7 @@ import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.notification.NotificationEventBusSupport;
 import org.eclipse.hono.notification.deviceregistry.AllDevicesOfTenantDeletedNotification;
 import org.eclipse.hono.notification.deviceregistry.DeviceChangeNotification;
@@ -67,7 +68,8 @@ public class AbstractDeviceManagementServiceTest {
         eventBus = mock(EventBus.class);
         final Vertx vertx = mock(Vertx.class);
         when(vertx.eventBus()).thenReturn(eventBus);
-        deviceManagementService = new TestDeviceManagementService(vertx);
+        final ServiceConfigProperties serviceConfig = new ServiceConfigProperties();
+        deviceManagementService = new TestDeviceManagementService(vertx, serviceConfig);
     }
 
     /**
@@ -223,8 +225,8 @@ public class AbstractDeviceManagementServiceTest {
 
     private static class TestDeviceManagementService extends AbstractDeviceManagementService {
 
-        TestDeviceManagementService(final Vertx vertx) {
-            super(vertx);
+        TestDeviceManagementService(final Vertx vertx, final ServiceConfigProperties serviceConfig) {
+            super(vertx, serviceConfig);
         }
 
         @Override

--- a/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
+++ b/services/device-registry-base/src/test/java/org/eclipse/hono/service/registration/AbstractRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,6 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+
 package org.eclipse.hono.service.registration;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -61,6 +62,10 @@ public interface AbstractRegistrationServiceTest {
      * The device identifier used in tests.
      */
     String DEVICE = "4711";
+    /**
+     * Invalid device identifier used in tests.
+     */
+    String INVALID_DEVICE = "**4711++";
     /**
      * The gateway identifier used in the tests.
      */

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ConfigPropertiesProducer.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ConfigPropertiesProducer.java
@@ -11,14 +11,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
 import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreOptions;
 import org.eclipse.hono.service.base.jdbc.config.JdbcDeviceStoreProperties;
 import org.eclipse.hono.service.base.jdbc.config.JdbcTenantStoreOptions;
 import org.eclipse.hono.service.base.jdbc.config.JdbcTenantStoreProperties;
+import org.eclipse.hono.service.http.HttpServiceConfigOptions;
+import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 
+import io.smallrye.config.ConfigMapping;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
@@ -52,5 +54,19 @@ public class ConfigPropertiesProducer {
     @Singleton
     public JdbcDeviceStoreProperties devicesProperties(final JdbcDeviceStoreOptions options) {
         return new JdbcDeviceStoreProperties(options);
+    }
+
+    /**
+     * Creates HTTP service configuration properties from existing options.
+     *
+     * @param options The options.
+     * @return The properties.
+     */
+    @Produces
+    @Singleton
+    public HttpServiceConfigProperties httpServiceConfigProperties(
+            @ConfigMapping(prefix = "hono.registry.http")
+            final HttpServiceConfigOptions options) {
+        return new HttpServiceConfigProperties(options);
     }
 }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/HttpServerFactory.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/HttpServerFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -14,10 +14,8 @@
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
 import org.eclipse.hono.deviceregistry.app.AbstractHttpServerFactory;
-import org.eclipse.hono.service.http.HttpServiceConfigOptions;
 import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 
-import io.smallrye.config.ConfigMapping;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -28,17 +26,11 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class HttpServerFactory extends AbstractHttpServerFactory {
 
-    private HttpServiceConfigProperties httpServerProperties;
-
     @Inject
-    void setHttpServerProperties(
-            @ConfigMapping(prefix = "hono.registry.http")
-            final HttpServiceConfigOptions endpointOptions) {
-        this.httpServerProperties = new HttpServiceConfigProperties(endpointOptions);
-    }
+    HttpServiceConfigProperties httpServerConfigProperties;
 
     @Override
     protected final HttpServiceConfigProperties getHttpServerProperties() {
-        return httpServerProperties;
+        return httpServerConfigProperties;
     }
 }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ManagementServicesProducer.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/app/ManagementServicesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,7 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-
 
 package org.eclipse.hono.deviceregistry.jdbc.app;
 
@@ -24,6 +23,7 @@ import org.eclipse.hono.service.auth.SpringBasedHonoPasswordEncoder;
 import org.eclipse.hono.service.base.jdbc.store.device.TableManagementStore;
 import org.eclipse.hono.service.base.jdbc.store.tenant.AdapterStore;
 import org.eclipse.hono.service.base.jdbc.store.tenant.ManagementStore;
+import org.eclipse.hono.service.http.HttpServiceConfigProperties;
 import org.eclipse.hono.service.management.credentials.CredentialsManagementService;
 import org.eclipse.hono.service.management.device.DeviceManagementService;
 import org.eclipse.hono.service.management.tenant.TenantManagementService;
@@ -75,6 +75,7 @@ public class ManagementServicesProducer {
      * @param devicesManagementStore The data store for accessing device data.
      * @param deviceServiceOptions The device management service configuration.
      * @param tenantInformationService The service for retrieving tenant information.
+     * @param httpServiceConfigProperties The HTTP service configuration.
      * @return The service.
      */
     @Produces
@@ -82,9 +83,14 @@ public class ManagementServicesProducer {
     public DeviceManagementService deviceManagementService(
             final TableManagementStore devicesManagementStore,
             final DeviceServiceOptions deviceServiceOptions,
-            final TenantInformationService tenantInformationService) {
+            final TenantInformationService tenantInformationService,
+            final HttpServiceConfigProperties httpServiceConfigProperties) {
 
-        final var service = new DeviceManagementServiceImpl(vertx, devicesManagementStore, deviceServiceOptions);
+        final var service = new DeviceManagementServiceImpl(
+                vertx,
+                devicesManagementStore,
+                deviceServiceOptions,
+                httpServiceConfigProperties);
         service.setTenantInformationService(tenantInformationService);
         return service;
     }

--- a/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
+++ b/services/device-registry-jdbc/src/main/java/org/eclipse/hono/deviceregistry/jdbc/impl/DeviceManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.eclipse.hono.client.ClientErrorException;
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceOptions;
 import org.eclipse.hono.deviceregistry.service.device.AbstractDeviceManagementService;
 import org.eclipse.hono.deviceregistry.service.device.DeviceKey;
@@ -53,9 +54,14 @@ public class DeviceManagementServiceImpl extends AbstractDeviceManagementService
      * @param vertx The vert.x instance to use.
      * @param store The backing store to use.
      * @param properties The service properties.
+     * @param serviceConfig The service config to use.
      */
-    public DeviceManagementServiceImpl(final Vertx vertx, final TableManagementStore store, final DeviceServiceOptions properties) {
-        super(vertx);
+    public DeviceManagementServiceImpl(
+            final Vertx vertx,
+            final TableManagementStore store,
+            final DeviceServiceOptions properties,
+            final ServiceConfigProperties serviceConfig) {
+        super(vertx, serviceConfig);
         this.store = store;
         this.ttl = Optional.of(CacheDirective.maxAgeDirective(properties.registrationTtl()));
         this.config = properties;

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/AbstractJdbcRegistryTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.jdbc.config.DeviceServiceOptions;
 import org.eclipse.hono.deviceregistry.jdbc.config.TenantServiceOptions;
 import org.eclipse.hono.deviceregistry.service.tenant.TenantInformationService;
@@ -129,6 +130,8 @@ abstract class AbstractJdbcRegistryTest {
         when(properties.credentialsTtl()).thenReturn(Duration.ofMinutes(1));
         when(properties.registrationTtl()).thenReturn(Duration.ofMinutes(1));
 
+        final ServiceConfigProperties serviceConfig = new ServiceConfigProperties();
+
         this.credentialsAdapter = new CredentialsServiceImpl(
                 DeviceStores.adapterStoreFactory().createTable(vertx, TRACER, jdbc, Optional.empty(), Optional.empty(), Optional.empty()),
                 properties
@@ -147,7 +150,8 @@ abstract class AbstractJdbcRegistryTest {
         this.registrationManagement = new DeviceManagementServiceImpl(
                 vertx,
                 DeviceStores.managementStoreFactory().createTable(vertx, TRACER, jdbc, Optional.empty(), Optional.empty(), Optional.empty()),
-                properties
+                properties,
+                serviceConfig
         );
 
         tenantInformationService = mock(TenantInformationService.class);

--- a/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedRegistrationServiceTest.java
+++ b/services/device-registry-jdbc/src/test/java/org/eclipse/hono/deviceregistry/jdbc/impl/JdbcBasedRegistrationServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -70,6 +70,20 @@ class JdbcBasedRegistrationServiceTest extends AbstractJdbcRegistryTest implemen
             .compose(ok -> getDeviceManagementService().createDevice(TENANT, Optional.empty(), new Device(), NoopSpan.INSTANCE))
             .onComplete(ctx.failing(t -> {
                 ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_FORBIDDEN));
+                ctx.completeNow();
+            }));
+    }
+
+    /**
+     * Verifies that a request to create device with device id which does not match the device id pattern fails with a 400.
+     *
+     * @param ctx The vert.x test context.
+     */
+    @Test
+    public void testCreateDeviceFailsIfDeviceIdDoesNotMatchDeviceIdPattern(final VertxTestContext ctx) {
+        getDeviceManagementService().createDevice(TENANT, Optional.of(INVALID_DEVICE), new Device(), NoopSpan.INSTANCE)
+            .onComplete(ctx.failing(t -> {
+                ctx.verify(() -> Assertions.assertServiceInvocationException(t, HttpURLConnection.HTTP_BAD_REQUEST));
                 ctx.completeNow();
             }));
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ConfigPropertiesProducer.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ConfigPropertiesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,6 +15,8 @@ package org.eclipse.hono.deviceregistry.mongodb.app;
 
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigOptions;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigOptions;
@@ -68,5 +70,18 @@ public class ConfigPropertiesProducer {
     public MongoDbBasedCredentialsConfigProperties credentialsServiceProperties(
             final MongoDbBasedCredentialsConfigOptions options) {
         return new MongoDbBasedCredentialsConfigProperties(options);
+    }
+
+    /**
+     * Creates HTTP service configuration properties from existing options.
+     *
+     * @param options The options.
+     * @return The properties.
+     */
+    @Produces
+    @Singleton
+    public MongoDbBasedHttpServiceConfigProperties httpServiceProperties(
+            final MongoDbBasedHttpServiceConfigOptions options) {
+        return new MongoDbBasedHttpServiceConfigProperties(options);
     }
 }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/HttpServerFactory.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/HttpServerFactory.java
@@ -17,7 +17,6 @@ package org.eclipse.hono.deviceregistry.mongodb.app;
 import java.util.Optional;
 
 import org.eclipse.hono.deviceregistry.app.AbstractHttpServerFactory;
-import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigOptions;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.server.DeviceRegistryHttpServer;
 import org.eclipse.hono.service.http.HttpServiceConfigProperties;
@@ -44,12 +43,8 @@ public class HttpServerFactory extends AbstractHttpServerFactory {
     @Inject
     MongoClient mongoClient;
 
-    private MongoDbBasedHttpServiceConfigProperties httpServerProperties;
-
     @Inject
-    void setHttpServerProperties(final MongoDbBasedHttpServiceConfigOptions endpointOptions) {
-        this.httpServerProperties = new MongoDbBasedHttpServiceConfigProperties(endpointOptions);
-    }
+    MongoDbBasedHttpServiceConfigProperties httpServerProperties;
 
     @Override
     protected final HttpServiceConfigProperties getHttpServerProperties() {

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ManagementServicesProducer.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/app/ManagementServicesProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,10 +11,10 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-
 package org.eclipse.hono.deviceregistry.mongodb.app;
 
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
+import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedHttpServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedTenantsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.model.CredentialsDao;
@@ -89,6 +89,7 @@ public class ManagementServicesProducer {
      * @param deviceDao The DAO for accessing device data.
      * @param credentialsDao The DAO for accessing credentials data.
      * @param tenantInformationService The service for retrieving tenant information.
+     * @param httpServiceConfigProperties The HTTP service configuration.
      * @return The service.
      */
     @Produces
@@ -96,13 +97,15 @@ public class ManagementServicesProducer {
     public DeviceManagementService deviceManagementService(
             final DeviceDao deviceDao,
             final CredentialsDao credentialsDao,
-            final TenantInformationService tenantInformationService) {
+            final TenantInformationService tenantInformationService,
+            final MongoDbBasedHttpServiceConfigProperties httpServiceConfigProperties) {
 
         final var service = new MongoDbBasedDeviceManagementService(
                 vertx,
                 deviceDao,
                 credentialsDao,
-                registrationServiceProperties);
+                registrationServiceProperties,
+                httpServiceConfigProperties);
         service.setTenantInformationService(tenantInformationService);
         return service;
     }

--- a/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceManagementService.java
+++ b/services/device-registry-mongodb/src/main/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedDeviceManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,6 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+
 package org.eclipse.hono.deviceregistry.mongodb.service;
 
 import java.net.HttpURLConnection;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.model.CredentialsDao;
 import org.eclipse.hono.deviceregistry.mongodb.model.DeviceDao;
@@ -62,14 +64,16 @@ public final class MongoDbBasedDeviceManagementService extends AbstractDeviceMan
      * @param deviceDao The data access object to use for accessing device data in the MongoDB.
      * @param credentialsDao The data access object to use for accessing credentials data in the MongoDB.
      * @param config The properties for configuring this service.
+     * @param serviceConfig The service config to use.
      * @throws NullPointerException if any of the parameters are {@code null}.
      */
     public MongoDbBasedDeviceManagementService(
             final Vertx vertx,
             final DeviceDao deviceDao,
             final CredentialsDao credentialsDao,
-            final MongoDbBasedRegistrationConfigProperties config) {
-        super(vertx);
+            final MongoDbBasedRegistrationConfigProperties config,
+            final ServiceConfigProperties serviceConfig) {
+        super(vertx, serviceConfig);
         Objects.requireNonNull(deviceDao);
         Objects.requireNonNull(credentialsDao);
         Objects.requireNonNull(config);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDBBasedDeviceManagementSearchDevicesTest.java
@@ -15,6 +15,7 @@ package org.eclipse.hono.deviceregistry.mongodb.service;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.model.MongoDbBasedCredentialsDao;
 import org.eclipse.hono.deviceregistry.mongodb.model.MongoDbBasedDeviceDao;
@@ -49,6 +50,7 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
     private static final String DB_NAME = "hono-search-devices-test";
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBBasedDeviceManagementSearchDevicesTest.class);
     private final MongoDbBasedRegistrationConfigProperties config = new MongoDbBasedRegistrationConfigProperties();
+    private final ServiceConfigProperties serviceConfig = new ServiceConfigProperties();
     private MongoDbBasedDeviceDao deviceDao;
     private MongoDbBasedCredentialsDao credentialsDao;
     private MongoDbBasedDeviceManagementService service;
@@ -65,7 +67,7 @@ public final class MongoDBBasedDeviceManagementSearchDevicesTest implements Abst
         vertx = Vertx.vertx();
         deviceDao = MongoDbTestUtils.getDeviceDao(vertx, DB_NAME);
         credentialsDao = MongoDbTestUtils.getCredentialsDao(vertx, DB_NAME);
-        service = new MongoDbBasedDeviceManagementService(vertx, deviceDao, credentialsDao, config);
+        service = new MongoDbBasedDeviceManagementService(vertx, deviceDao, credentialsDao, config, serviceConfig);
         Future.all(deviceDao.createIndices(), credentialsDao.createIndices()).onComplete(testContext.succeedingThenComplete());
     }
 

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbBasedCredentialServiceTest.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,6 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+
 package org.eclipse.hono.deviceregistry.mongodb.service;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.hono.config.ServiceConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedCredentialsConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.config.MongoDbBasedRegistrationConfigProperties;
 import org.eclipse.hono.deviceregistry.mongodb.model.MongoDbBasedCredentialsDao;
@@ -80,6 +82,7 @@ public class MongoDbBasedCredentialServiceTest implements CredentialsServiceTest
 
     private final MongoDbBasedCredentialsConfigProperties credentialsServiceConfig = new MongoDbBasedCredentialsConfigProperties();
     private final MongoDbBasedRegistrationConfigProperties registrationServiceConfig = new MongoDbBasedRegistrationConfigProperties();
+    private final ServiceConfigProperties serviceConfig = new ServiceConfigProperties();
 
     private MongoDbBasedCredentialsDao credentialsDao;
     private MongoDbBasedDeviceDao deviceDao;
@@ -112,7 +115,8 @@ public class MongoDbBasedCredentialServiceTest implements CredentialsServiceTest
                 vertx,
                 deviceDao,
                 credentialsDao,
-                registrationServiceConfig);
+                registrationServiceConfig,
+                serviceConfig);
 
         Future.all(deviceDao.createIndices(), credentialsDao.createIndices())
             .onComplete(ctx.succeedingThenComplete());


### PR DESCRIPTION
This is initial implementation idea I had and thought it should cover all the paths device is created to prevent creating any deivce with id which does not conform to the device id pattern.

I think I need to look at integration tests also but need to do that bit later.