### PR TITLE
Update jline to 3.26.1.

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli-shell-jline3</artifactId>
-      <version>4.7.4</version>
+      <version>4.7.6</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>
@@ -183,7 +183,7 @@
         <!--  include all JSSE related classes -->
         <quarkus.native.enable-all-security-services>true</quarkus.native.enable-all-security-services>
         <quarkus.native.resources.includes>hono-cli-build.properties</quarkus.native.resources.includes>
-        <quarkus.native.additional-build-args>--initialize-at-run-time=org.jline.nativ.JLineLibrary</quarkus.native.additional-build-args>
+        <quarkus.native.additional-build-args>--initialize-at-run-time=org.jline.nativ</quarkus.native.additional-build-args>
       </properties>
     </profile>
   </profiles>

--- a/legal/src/main/resources/legal/DEPENDENCIES
+++ b/legal/src/main/resources/legal/DEPENDENCIES
@@ -50,7 +50,7 @@ maven/mavencentral/com.squareup.okio/okio/3.6.0, Apache-2.0, approved, #11155
 maven/mavencentral/com.squareup.okio/okio-jvm/3.6.0, Apache-2.0, approved, #11158
 maven/mavencentral/com.squareup/protoparser/4.0.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/info.picocli/picocli/4.7.5, Apache-2.0, approved, #4365
-maven/mavencentral/info.picocli/picocli-shell-jline3/4.7.4, Apache-2.0, approved, #10606
+maven/mavencentral/info.picocli/picocli-shell-jline3/4.7.6, Apache-2.0, approved, #10606
 maven/mavencentral/io.agroal/agroal-api/2.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.agroal/agroal-narayana/2.3, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.agroal/agroal-pool/2.3, Apache-2.0, approved, clearlydefined
@@ -337,7 +337,7 @@ maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.9.22, Apache-2.0,
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.9.22, Apache-2.0, approved, #14188
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8/1.9.22, Apache-2.0, approved, #14185
 maven/mavencentral/org.jgroups/jgroups/5.2.23.Final, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.jline/jline/3.23.0, BSD-3-Clause AND Apache-2.0, approved, #10622
+maven/mavencentral/org.jline/jline/3.26.1, BSD-3-Clause AND Apache-2.0, approved, #14872
 maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, BSD-2-Clause, approved, CQ17408
 maven/mavencentral/org.locationtech.jts/jts-core/1.17.0, EPL-2.0, approved, locationtech.jts
 maven/mavencentral/org.lz4/lz4-java/1.8.0, Apache-2.0, approved, clearlydefined

--- a/legal/src/main/resources/legal/hono-maven.deps
+++ b/legal/src/main/resources/legal/hono-maven.deps
@@ -50,7 +50,7 @@ com.squareup.okio:okio:jar:3.6.0
 com.squareup.okio:okio-jvm:jar:3.6.0
 com.squareup:protoparser:jar:4.0.3
 info.picocli:picocli:jar:4.7.5
-info.picocli:picocli-shell-jline3:jar:4.7.4
+info.picocli:picocli-shell-jline3:jar:4.7.6
 io.agroal:agroal-api:jar:2.3
 io.agroal:agroal-narayana:jar:2.3
 io.agroal:agroal-pool:jar:2.3
@@ -342,7 +342,7 @@ org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.22
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.9.22
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.22
 org.jgroups:jgroups:jar:5.2.23.Final
-org.jline:jline:jar:3.23.0
+org.jline:jline:jar:3.26.1
 org.latencyutils:LatencyUtils:jar:2.0.3
 org.locationtech.jts:jts-core:jar:1.17.0
 org.lz4:lz4-java:jar:1.8.0


### PR DESCRIPTION
The jline dependency version 3.23.0 used in the Hono CLI has a CVE assigned to it (CVE-2023-50572), therefore updating it.