### PR TITLE
[#3647] Prometheus based limits check uses always port 9090

### DIFF
--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/PrometheusBasedResourceLimitCheckOptions.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/PrometheusBasedResourceLimitCheckOptions.java
@@ -79,4 +79,14 @@ public interface PrometheusBasedResourceLimitCheckOptions {
      */
     @WithDefault("1000")
     int connectTimeout();
+
+    /**
+     * Gets the TCP port of the server that this client is configured to connect to.
+     * <p>
+     * The default value of this property is 9090.
+     *
+     * @return The port number.
+     */
+    @WithDefault("9090")
+    int port();
 }

--- a/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/PrometheusBasedResourceLimitChecksConfig.java
+++ b/adapter-base/src/main/java/org/eclipse/hono/adapter/resourcelimits/PrometheusBasedResourceLimitChecksConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,6 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
+
 package org.eclipse.hono.adapter.resourcelimits;
 
 import org.eclipse.hono.client.amqp.config.AuthenticatingClientConfigProperties;
@@ -68,7 +69,7 @@ public class PrometheusBasedResourceLimitChecksConfig extends AuthenticatingClie
      */
     public PrometheusBasedResourceLimitChecksConfig(final PrometheusBasedResourceLimitCheckOptions options) {
         super(options.clientOptions());
-        setPort(9090);
+        setPort(options.port());
         this.cacheMaxSize = options.cacheMaxSize();
         this.cacheMinSize = options.cacheMinSize();
         this.cacheTimeout = options.cacheTimeout();

--- a/adapter-base/src/test/java/org/eclipse/hono/adapter/resourcelimits/PrometheusBasedResourceLimitCheckOptionsTest.java
+++ b/adapter-base/src/test/java/org/eclipse/hono/adapter/resourcelimits/PrometheusBasedResourceLimitCheckOptionsTest.java
@@ -43,5 +43,6 @@ class PrometheusBasedResourceLimitCheckOptionsTest {
         // client options
         assertThat(props.isHostConfigured()).isTrue();
         assertThat(props.getHost()).isEqualTo("prometheus");
+        assertThat(props.getPort()).isEqualTo(888);
     }
 }

--- a/adapter-base/src/test/resources/resource-limit-check-options.yaml
+++ b/adapter-base/src/test/resources/resource-limit-check-options.yaml
@@ -5,5 +5,6 @@ hono:
       cacheMinSize: 5555
       cacheTimeout: 555
       connectTimeout: 777
-      host: "prometheus"
       queryTimeout: 2222
+      host: "prometheus"
+      port: 888


### PR DESCRIPTION
Read `port` value into separate Prometheus specific option with default value `9090` and use it to instantiate Prometheus config.