### PR TITLE
Fix web site build job

### DIFF
--- a/jenkins/Hono-Website-Pipeline-Declarative.groovy
+++ b/jenkins/Hono-Website-Pipeline-Declarative.groovy
@@ -34,13 +34,13 @@ pipeline {
               value: "/home/jenkins"
             resources:
               limits:
-                memory: "512Mi"
+                memory: "1Gi"
                 cpu: "1"
               requests:
-                memory: "512Mi"
+                memory: "1Gi"
                 cpu: "1"
           - name: "hugo"
-            image: "cibuilds/hugo:0.102"
+            image: "cibuilds/hugo:0.123.8"
             command:
             - cat
             tty: true
@@ -114,7 +114,7 @@ pipeline {
             # removing them, so they don't get deployed.
             rm themes/hugo-universal-theme/static/img/*
             echo "building home page..."
-            hugo -v -d "${WEBSITE_REPO_DIR}"
+            hugo -d "${WEBSITE_REPO_DIR}"
           '''
         }
       }
@@ -170,7 +170,7 @@ pipeline {
           sh '''#!/bin/bash
             echo "building documentation..."
             cd "${DOC_ASSEMBLY_DIR}"
-            hugo -v -d "${WEBSITE_REPO_DIR}/docs" --config config.toml,config_version.toml
+            hugo -d "${WEBSITE_REPO_DIR}/docs" --config config.toml,config_version.toml
           '''
         }
       }

--- a/site/build-site.bat
+++ b/site/build-site.bat
@@ -1,5 +1,5 @@
 @rem ***************************************************************************
-@rem Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+@rem Copyright (c) 2016 Contributors to the Eclipse Foundation
 @rem
 @rem See the NOTICE file(s) distributed with this work for additional
 @rem information regarding copyright ownership.
@@ -30,19 +30,19 @@ IF ERRORLEVEL 1 (
 cd homepage
 IF NOT "%~1"==""  (
   ECHO Going to build homepage in directory: %1
-  hugo -v -d %1
+  hugo -d %1
 ) ELSE (
   ECHO Going to build homepage in default directory...
-  hugo -v
+  hugo
 )
 cd ..
 
 cd documentation
 IF NOT "%~1"==""  (
   ECHO Going to build documentation in directory: %1\docs
-  hugo -v -d %1\docs
+  hugo -d %1\docs
 ) ELSE (
   ECHO Going to build documentation in default directory...
-  hugo -v
+  hugo
 )
 cd ..

--- a/site/build-site.sh
+++ b/site/build-site.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
+# Copyright (c) 2016 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -12,30 +12,64 @@
 # SPDX-License-Identifier: EPL-2.0
 #*******************************************************************************
 
+target="public"
+hugo_cmd="hugo"
 
-if ! hugo version; then
-  echo "Please install \"hugo\" to be able to build the hono documentation. See readme.md for further details."
+print_usage() {
+  cmd_name=$(basename "$0")
+  cat <<EOF >&2 
+Usage: ${cmd_name} OPTIONS ...
+
+OPTIONS
+
+-h | --help          Display this usage information.
+-H | --hugo          The path to the Hugo executable to use for building the site. [$hugo_cmd]
+-t | --target PATH   The path to the folder to contain the site. [$target]
+
+EOF
+}
+
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
+  -h | --help )
+    print_usage
+    exit 1
+    ;;
+  -H | --hugo )
+    shift; hugo_cmd=$1
+    ;;
+  -t | --target )
+    shift; target=$1
+    ;;
+  *)
+    echo "Ignoring unknown option: $1"
+    echo "Run with flag -h for usage"
+    ;;
+esac; shift; done
+if [[ "$1" == '--' ]]; then shift; fi
+
+hugo_version=$($hugo_cmd version)
+if [[ -z "$hugo_version" ]]
+then
+  echo "Could not find \"$hugo_cmd\" executable on your PATH. See readme.md for further details."
   exit 0
 fi
 
-if [ "$1" ]
+submodule_status=$(git submodule status)
+if [[ -z "$submodule_status" ]]
 then
-  TARGET="$1"
-else
-  TARGET="public"
-fi
-
-if ! git submodule status; then
   echo "Initializing submodules containing Hugo themes."
   git submodule update --init
+  echo
 fi
 
 cd homepage || exit
-echo "Building homepage in directory: $TARGET"
-hugo -v -d $TARGET
+echo "Building homepage in directory: $target"
+$hugo_cmd -d $target
+echo
+echo
 cd .. 
 
 cd documentation || exit
-echo "Building documentation in directory: $TARGET/docs"
-hugo -v -d $TARGET/docs
+echo "Building documentation in directory: $target/docs"
+$hugo_cmd -d $target/docs
 cd ..


### PR DESCRIPTION
The web site Jenkins build job had been failing sporadically. It seems like this was because of too little memory available on the JNLP container. The memory has been increased to 1GB to address this.
Also, the build job has been changed to use Hugo 0.123.8 which is the last Hugo version that is compatible with the used Hugo themes.