### PR TITLE
Several small fixes

### DIFF
--- a/adapters/parent/pom.xml
+++ b/adapters/parent/pom.xml
@@ -27,10 +27,10 @@
   <description>Defines common dependencies and build profiles for Quarkus-based protocol adapter implementations</description>
 
   <properties>
-    <!-- 
+    <!--
       hono.authType poperty is needed while quarkus resolve dev properties (it
       contains hono.authType=${hono.authType}). That's why we specify here.
-      For services it is delegating. For adapters, hono auth is disabled  
+      For services it is delegating. For adapters, hono auth is disabled
     -->
     <hono.authType>n/a</hono.authType>
 
@@ -148,7 +148,7 @@ hono.kafka.commandResponse.producerConfig."request.timeout.ms"=${kafka-client.pr
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
                         <JAVA_MAIN_CLASS>io.quarkus.bootstrap.runner.QuarkusEntryPoint</JAVA_MAIN_CLASS>
-                        <JAVA_LIB_DIR>app/*:quarkus/*:lib/boot/*:lib/main/*:extensions/*</JAVA_LIB_DIR>
+                        <JAVA_LIB_DIR>extensions/*</JAVA_LIB_DIR>
                         <!--
                           - make sure that the size of (ephemeral) keys used for Diffie-Hellman exchanges
                             match the length of the (private) key used for the service's identity

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,7 +41,7 @@
     <java-base-image.name>docker.io/library/eclipse-temurin:21-jre-ubi9-minimal</java-base-image.name>
     <jjwt.version>0.13.0</jjwt.version>
     <kafka-clients.version>3.9.2</kafka-clients.version>
-    <kafka-image.name>docker.io/confluentinc/cp-kafka:7.9.5</kafka-image.name>
+    <kafka-image.name>docker.io/apache/kafka:4.3.1</kafka-image.name>
     <logback.version>1.5.34</logback.version>
     <mongodb-image.name>docker.io/library/mongo:7.0</mongodb-image.name>
     <native.image.name>quay.io/quarkus/ubi9-quarkus-micro-image:2.0</native.image.name>

--- a/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
+++ b/clients/kafka-common/src/main/java/org/eclipse/hono/client/kafka/consumer/HonoKafkaConsumer.java
@@ -766,8 +766,8 @@ public class HonoKafkaConsumer<V> implements Lifecycle, ServiceClient {
                 // invoked on the Kafka polling thread, not the event loop thread!
                 final Set<TopicPartition> partitionsSet = Helper.from(partitions);
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("partitions assigned: [{}] [client-id: {}]",
-                            HonoKafkaConsumerHelper.getPartitionsDebugString(partitions), getClientId());
+                    LOG.debug("partitions assigned [client-id: {}]: [{}]",
+                            getClientId(), HonoKafkaConsumerHelper.getPartitionsDebugString(partitions));
                 }
                 ensurePositionsHaveBeenSetIfNeeded(partitionsSet);
                 updateSubscribedTopicPatternTopicsAndRemoveMetrics();

--- a/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
+++ b/services/command-router-base/src/main/java/org/eclipse/hono/commandrouter/impl/kafka/KafkaBasedCommandConsumerFactoryImpl.java
@@ -255,6 +255,10 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
                         // Doing it here will speed up the first invocation of "createCommandConsumer" for this tenant.
                         final String tenantId = notification.getTenantId();
                         final String topic = new HonoTopic(HonoTopic.Type.COMMAND, tenantId).toString();
+                        LOG.info("""
+                                received notification about newly created tenant [id: {}], \
+                                ensuring corresponding command topic [{}] is among subscribed topics...""",
+                                tenantId, topic);
                         kafkaConsumer.ensureTopicIsAmongSubscribedTopicPatternTopics(topic);
                     }
                 });
@@ -280,7 +284,7 @@ public class KafkaBasedCommandConsumerFactoryImpl implements CommandConsumerFact
             LOG.debug("createCommandConsumer: topic is already subscribed [{}]", topic);
             return Future.succeededFuture();
         }
-        LOG.debug("""
+        LOG.info("""
                 createCommandConsumer: topic not subscribed; check for its existence, triggering auto-creation \
                 if enabled [{}]\
                 """, topic);

--- a/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
+++ b/services/device-registry-mongodb/src/test/java/org/eclipse/hono/deviceregistry/mongodb/service/MongoDbTestUtils.java
@@ -33,7 +33,7 @@ import io.vertx.ext.mongo.MongoClient;
 public final class MongoDbTestUtils {
 
     private static final MongoDBContainer MONGO_DB_CONTAINER;
-    private static final String MONGO_DB_IMAGE_NAME = System.getProperty("mongoDbImageName", "mongo:6.0");
+    private static final String MONGO_DB_IMAGE_NAME = System.getProperty("mongoDbImageName", "mongo:7.0");
     private static final Logger LOG = LoggerFactory.getLogger(MongoDbTestUtils.class);
 
     static {

--- a/services/parent/pom.xml
+++ b/services/parent/pom.xml
@@ -146,7 +146,7 @@
                         <JAVA_MAJOR_VERSION>${maven.compiler.release}</JAVA_MAJOR_VERSION>
                         <JAVA_APP_NAME>${project.artifactId}</JAVA_APP_NAME>
                         <JAVA_MAIN_CLASS>io.quarkus.bootstrap.runner.QuarkusEntryPoint</JAVA_MAIN_CLASS>
-                        <JAVA_LIB_DIR>app/*:quarkus/*:lib/boot/*:lib/main/*:extensions/*</JAVA_LIB_DIR>
+                        <JAVA_LIB_DIR>extensions/*</JAVA_LIB_DIR>
                         <!--
                           - make sure that the size of (ephemeral) keys used for Diffie-Hellman exchanges
                             match the length of the (private) key used for the service's identity

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -120,13 +120,13 @@ mvn verify -Prun-tests,jaeger -Ddocker.keepRunning -Dit.test=TelemetryHttpIT#tes
 ```
 
 Note that in order to be able to view the traces after a test run, the `docker.keepRunning` property has
-to be used as well, as shown above.  
+to be used as well, as shown above.
 
 The Jaeger UI, showing the traces of the test run, can be accessed at `http://localhost:18080`
 
 if the Docker engine is running on `localhost`, otherwise the appropriate Docker host has to be used in the
 above URL. To choose a different port for the Jaeger UI, set the `jaeger.query.port` Maven property to the
-desired port when running the tests. 
+desired port when running the tests.
 
 Start subsequent test runs using the running containers with the `useRunningContainers` Maven profile, e.g.:
 

--- a/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
+++ b/tests/src/test/java/org/eclipse/hono/tests/http/HttpTestBase.java
@@ -1124,11 +1124,11 @@ public abstract class HttpTestBase {
             });
             switch (msg.getContentType()) {
             case "text/msg1":
-                logger.debug("received first message");
+                            logger.info("received first message");
                 firstMessageReceived.complete();
                 break;
             case "text/msg2":
-                logger.debug("received second message");
+                            logger.info("received second message");
                 secondMessageReceived.complete();
                 break;
             default:
@@ -1234,8 +1234,8 @@ public abstract class HttpTestBase {
         final var emptyResponseReceived = ctx.checkpoint();
         final int ttdSeconds = 4;
 
-        helper.registry.addDeviceForTenant(tenantId, 
-                new Tenant(), deviceId, PWD)
+        helper.registry.addDeviceForTenant(tenantId,
+                        new Tenant(), deviceId, PWD)
             .compose(ok -> createConsumer(tenantId, msg -> {
                 logger.trace("received message");
                 msg.getTimeUntilDisconnectNotification()

--- a/tests/src/test/resources/commandrouter/logging-quarkus-prod.yml
+++ b/tests/src/test/resources/commandrouter/logging-quarkus-prod.yml
@@ -5,6 +5,9 @@ quarkus:
         level: WARN
       "org.eclipse.hono":
         level: INFO
+      # temporary debug logging for Kafka consumer in order to investigate flaky integration test
+      "org.eclipse.hono.client.kafka.consumer":
+        level: DEBUG
       "org.eclipse.hono.commandrouter.impl.kafka":
         level: INFO
       "org.eclipse.hono.client.impl.HonoConnectionImpl":


### PR DESCRIPTION
Adopt latest fixes from master branch to use Apache Kafka 4.3.1 container image for integration tests and temporarily increase log level for  getting insight into reasons for flaky integration test failures.